### PR TITLE
upgrade playht to latest engine

### DIFF
--- a/tests/synthesizer/conftest.py
+++ b/tests/synthesizer/conftest.py
@@ -76,7 +76,7 @@ async def fixture_eleven_labs_synthesizer_env_api_key():
 
 def create_play_ht_request_handler():
     def request_handler(url, headers, **kwargs):
-        if headers["AUTHORIZATION"] != f"Bearer {MOCK_API_KEY}":
+        if headers["AUTHORIZATION"] != MOCK_API_KEY:
             return CallbackResult(status=401)
         if headers["X-USER-ID"] != MOCK_USER_ID:
             return CallbackResult(status=401)

--- a/vocode/streaming/models/synthesizer.py
+++ b/vocode/streaming/models/synthesizer.py
@@ -128,7 +128,7 @@ class ElevenLabsSynthesizerConfig(
     @validator("optimize_streaming_latency")
     def optimize_streaming_latency_check(cls, optimize_streaming_latency):
         if optimize_streaming_latency is not None and not (
-            0 <= optimize_streaming_latency <= 4
+                0 <= optimize_streaming_latency <= 4
         ):
             raise ValueError("optimize_streaming_latency must be between 0 and 4.")
         return optimize_streaming_latency
@@ -162,7 +162,8 @@ class CoquiSynthesizerConfig(SynthesizerConfig, type=SynthesizerType.COQUI.value
         return voice_id or COQUI_DEFAULT_SPEAKER_ID
 
 
-PLAYHT_DEFAULT_VOICE_ID = "larry"
+PLAYHT_DEFAULT_VOICE = "s3://peregrine-voices/mel28/manifest.json"
+PLAYHT_DEFAULT_VOICE_ENGINE = "PlayHT2.0-turbo"
 
 
 class PlayHtSynthesizerConfig(SynthesizerConfig, type=SynthesizerType.PLAY_HT.value):
@@ -171,7 +172,8 @@ class PlayHtSynthesizerConfig(SynthesizerConfig, type=SynthesizerType.PLAY_HT.va
     speed: Optional[int] = None
     seed: Optional[int] = None
     temperature: Optional[int] = None
-    voice_id: str = PLAYHT_DEFAULT_VOICE_ID
+    voice: str = PLAYHT_DEFAULT_VOICE
+    voice_engine: str = PLAYHT_DEFAULT_VOICE_ENGINE
     experimental_streaming: bool = False
 
 

--- a/vocode/streaming/synthesizer/play_ht_synthesizer.py
+++ b/vocode/streaming/synthesizer/play_ht_synthesizer.py
@@ -14,7 +14,7 @@ from vocode.streaming.synthesizer.base_synthesizer import (
 )
 from vocode.streaming.utils.mp3_helper import decode_mp3
 
-TTS_ENDPOINT = "https://play.ht/api/v2/tts/stream"
+TTS_ENDPOINT = "https://api.play.ht/api/v2/tts/stream"
 
 
 class PlayHtSynthesizer(BaseSynthesizer[PlayHtSynthesizerConfig]):
@@ -46,16 +46,17 @@ class PlayHtSynthesizer(BaseSynthesizer[PlayHtSynthesizerConfig]):
         bot_sentiment: Optional[BotSentiment] = None,
     ) -> SynthesisResult:
         headers = {
-            "AUTHORIZATION": f"Bearer {self.api_key}",
+            "AUTHORIZATION": self.api_key,
             "X-USER-ID": self.user_id,
             "Accept": "audio/mpeg",
             "Content-Type": "application/json",
         }
         body = {
             "quality": "draft",
-            "voice": self.synthesizer_config.voice_id,
+            "voice": self.synthesizer_config.voice,
             "text": message.text,
             "sample_rate": self.synthesizer_config.sampling_rate,
+            "voice_engine": self.synthesizer_config.voice_engine,
         }
         if self.synthesizer_config.speed:
             body["speed"] = self.synthesizer_config.speed


### PR DESCRIPTION
This pull request implements the upgrade of the Play.ht synthesizer engine to the latest version, PlayHT2.0-turbo.
Documentation for API Reference: https://docs.play.ht/reference/http-api-audio-streaming