### PR TITLE
Fixing path in how-to-use-it

### DIFF
--- a/docs/open-source/how-to-use-it.mdx
+++ b/docs/open-source/how-to-use-it.mdx
@@ -10,8 +10,8 @@ additional languages.
 
 ### Getting Started with the Open Source Python Library
 
-Please refer to the [Python quickstart](docs/open-source/python-quickstart.mdx) guide.
+Please refer to the [Python quickstart](/open-source/python-quickstart.mdx) guide.
 
 ### Getting Started with the Open Source React Library
 
-Please refer to the [React quickstart](docs/open-source/react-quickstart.mdx) guide.
+Please refer to the [React quickstart](/open-source/react-quickstart.mdx) guide.

--- a/docs/open-source/how-to-use-it.mdx
+++ b/docs/open-source/how-to-use-it.mdx
@@ -10,8 +10,8 @@ additional languages.
 
 ### Getting Started with the Open Source Python Library
 
-Please refer to the [Python quickstart](/open-source/python-quickstart.mdx) guide.
+Please refer to the [Python quickstart](/docs/open-source/python-quickstart.mdx) guide.
 
 ### Getting Started with the Open Source React Library
 
-Please refer to the [React quickstart](/open-source/react-quickstart.mdx) guide.
+Please refer to the [React quickstart](/docs/open-source/react-quickstart.mdx) guide.

--- a/docs/open-source/how-to-use-it.mdx
+++ b/docs/open-source/how-to-use-it.mdx
@@ -10,8 +10,8 @@ additional languages.
 
 ### Getting Started with the Open Source Python Library
 
-Please refer to the [Python quickstart](/open-source/python-quickstart) guide.
+Please refer to the [Python quickstart](docs/open-source/python-quickstart.mdx) guide.
 
 ### Getting Started with the Open Source React Library
 
-Please refer to the [React quickstart](/open-source/react-quickstart) guide.
+Please refer to the [React quickstart](docs/open-source/react-quickstart.mdx) guide.


### PR DESCRIPTION
Python Quickstart and React Quickstart existing paths take us to an empty directory which throws a 404. This fixes the path to assist the reader in reaching the right file.