### PR TITLE
Bug twilio sid not passed

### DIFF
--- a/vocode/streaming/action/worker.py
+++ b/vocode/streaming/action/worker.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 import asyncio
 from vocode.streaming.action.factory import ActionFactory
 from vocode.streaming.agent.base_agent import ActionResultAgentInput, AgentInput
-from vocode.streaming.models.actions import (
-    ActionInput,
-    TwilioPhoneCallActionInput,
-    VonagePhoneCallActionInput,
+from vocode.streaming.models.actions import ActionInput
+from vocode.streaming.utils.state_manager import (
+    ConversationStateManager,
+    TwilioCallStateManager,
+    VonageCallStateManager,
 )
-from vocode.streaming.utils.state_manager import ConversationStateManager
 from vocode.streaming.utils.worker import (
     InterruptibleEvent,
     InterruptibleEventFactory,
@@ -47,13 +47,13 @@ class ActionsWorker(InterruptibleWorker):
                 action_input=action_input,
                 action_output=action_output,
                 vonage_uuid=(
-                    action_input.vonage_uuid
-                    if isinstance(action_input, VonagePhoneCallActionInput)
+                    self.conversation_state_manager._call.vonage_uuid
+                    if isinstance(self.conversation_state_manager, VonageCallStateManager)
                     else None
                 ),
                 twilio_sid=(
-                    action_input.twilio_sid
-                    if isinstance(action_input, TwilioPhoneCallActionInput)
+                    self.conversation_state_manager._call.twilio_sid
+                    if isinstance(self.conversation_state_manager, TwilioCallStateManager)
                     else None
                 ),
                 is_quiet=action.quiet,

--- a/vocode/streaming/action/worker.py
+++ b/vocode/streaming/action/worker.py
@@ -47,12 +47,12 @@ class ActionsWorker(InterruptibleWorker):
                 action_input=action_input,
                 action_output=action_output,
                 vonage_uuid=(
-                    self.conversation_state_manager._call.vonage_uuid
+                    self.conversation_state_manager.get_vonage_uuid()
                     if isinstance(self.conversation_state_manager, VonageCallStateManager)
                     else None
                 ),
                 twilio_sid=(
-                    self.conversation_state_manager._call.twilio_sid
+                    self.conversation_state_manager.get_twilio_sid()
                     if isinstance(self.conversation_state_manager, TwilioCallStateManager)
                     else None
                 ),

--- a/vocode/streaming/utils/state_manager.py
+++ b/vocode/streaming/utils/state_manager.py
@@ -59,8 +59,14 @@ class VonageCallStateManager(ConversationStateManager):
         super().__init__(call)
         self._call = call
 
+    def get_vonage_uuid(self) -> str:
+        return self._call.vonage_uuid
+
 
 class TwilioCallStateManager(ConversationStateManager):
     def __init__(self, call: "TwilioCall"):
         super().__init__(call)
         self._call = call
+
+    def get_twilio_sid(self) -> str:
+        return self._call.twilio_sid


### PR DESCRIPTION
**Hi guys. Sorry, I had accidentally closed PR [#544](https://github.com/vocodedev/vocode-python/pull/544), so I'm re-opening it here. For your convenience and for tracking, I've copied my comments from that closed request here**

In certain cases, the ActionWorker class does not correctly pass the `twilio_sid` or `vonage_uuid`. This is because the `action_input` is not always a reliable source of truth for obtaining these vars. Instead, this fix uses `ConversationStateManager` which is a more reliable method to obtaining these variables.

Below is an example of why we need this. I've included two log snippets. The first snippet shows the bug, and the second snippet shows how it's corrected. 

Draw your attention to how `twilio_sid` is set to `None` in the first set of logs (the buggy version). This can result in certain actions that require the `twilio_sid` to fail, such as `TransferCall`. This typically occurs when many actions are called back-to-back without having the user speak in between. 

(Note: I've used `pprint` to format some of the output better)
```
INFO:     Started server process [50430]                              
INFO:     Waiting for application startup.                            
INFO:     Application startup complete.                               
INFO:     Uvicorn running on http://127.0.0.1:3000 (Press CTRL+C to quit)                                                                   
INFO:     13.250.230.15:0 - "POST /3055551234 HTTP/1.1" 200 OK                                                                              
INFO:     ('13.250.230.15', 0) - "WebSocket /connect_call/4mpVUv9d92Vl2fAXmW9Gig" [accepted]                                                
INFO:     connection open                                                                                                                   
2024-05-16 12:38:37,803 - streaming_conversation.py:122 - process - INFO - [4mpVUv9d92Vl2fAXmW9Gig] Ignoring empty transcription                                                                         
2024-05-16 12:38:38,791 - base_agent.py:220 - handle_generate_response - INFO - [4mpVUv9d92Vl2fAXmW9Gig]                                    
                                                                      
{'agent_response_tracker': None,                                                                                                            
 'conversation_id': '4mpVUv9d92Vl2fAXmW9Gig',                         
 'transcription': {'confidence': 0.9995117,                           
                   'is_final': True,                                  
                   'is_interrupt': False,  
                   'message': " Yes. I'd like to speak to John, please."},                                                                 
 'twilio_sid': '7d0d360b-2eaf-4902-846c-859e41ab73ea',                                                                                      
 'vonage_uuid': None}                                                                                                                       
                                                                                                                                            
2024-05-16 12:38:41,656 - base_agent.py:220 - handle_generate_response - INFO - [4mpVUv9d92Vl2fAXmW9Gig]                                    
                                                                      
{'action_input': {'action_config': {'phone_number': '3055551234'},
                  'conversation_id': '4mpVUv9d92Vl2fAXmW9Gig',        
                  'params': {},                                       
                  'user_message_tracker': {'_value': False,           
                                           '_waiters': deque([])}},   
 'action_output': {'action_type': 'action_get_company_directory',
                   'response': {'company_directory': [{'availability': None,                                                                
                                                       'email': None,                                                                       
                                                       'first_name': 'John',                                                               
                                                       'id': 52,                                                                            
                                                       'is_away': False,                                       
                                                       'last_name': 'Smith',                                                               
                                                       'on_vacation': False,                                                                
                                                       'phone': '3055559999',                                                               
                                                       'return_date': None}]}},                                                             
 'agent_response_tracker': None,                                      
 'conversation_id': '4mpVUv9d92Vl2fAXmW9Gig',   
 'is_quiet': False,                                                   
 'twilio_sid': None,   <---- **** THIS SHOULD NOT BE NONE ****                                                                           
 'vonage_uuid': None}                                                 
                                                                                                                                            
                                                                                                                                            
{'day_of_week': 'Thursday', 'date': '2024-05-16', 'time': '12:38:42'}                                                                       
2024-05-16 12:38:42,524 - base_agent.py:220 - handle_generate_response - INFO - [4mpVUv9d92Vl2fAXmW9Gig] 
```

Now see the logs after my adjustments
```
INFO:     Started server process [51058]                                                                                                    
INFO:     Waiting for application startup.                                                                                                  
INFO:     Application startup complete.                                                                                                     
INFO:     Uvicorn running on http://127.0.0.1:3000 (Press CTRL+C to quit)                                                                   
                                                                                                                                            
                                                                                                                                            
INFO:     13.250.230.15:0 - "POST /3055551234 HTTP/1.1" 200 OK                                                                              
INFO:     ('13.250.230.15', 0) - "WebSocket /connect_call/kk2Yv36Y06B3owrc-XE3nQ" [accepted]                                                
INFO:     connection open                                                                                                                   
2024-05-16 12:55:37,524 - streaming_conversation.py:122 - process - INFO - [kk2Yv36Y06B3owrc-XE3nQ] Ignoring empty transcription            
2024-05-16 12:55:38,533 - streaming_conversation.py:122 - process - INFO - [kk2Yv36Y06B3owrc-XE3nQ] Ignoring empty transcription                                                                
2024-05-16 12:55:38,725 - base_agent.py:220 - handle_generate_response - INFO - [kk2Yv36Y06B3owrc-XE3nQ]                                    

{'agent_response_tracker': None,
 'conversation_id': 'kk2Yv36Y06B3owrc-XE3nQ',
 'transcription': {'confidence': 0.9992676,
                   'is_final': True,
                   'is_interrupt': False,
                   'message': " Yeah. I'd like to speak to John."},
 'twilio_sid': '438c3875-4db7-4990-a1a1-2009a620d32b',
 'vonage_uuid': None}


2024-05-16 12:55:41,087 - base_agent.py:220 - handle_generate_response - INFO - [kk2Yv36Y06B3owrc-XE3nQ] 

{'action_input': {'action_config': {'phone_number': '3055551234'},
                  'conversation_id': 'kk2Yv36Y06B3owrc-XE3nQ',
                  'params': {},
                  'user_message_tracker': {'_value': False,
                                           '_waiters': deque([])}},
 'action_output': {'action_type': 'action_get_company_directory',
                   'response': {'company_directory': [{'availability': None,
                                                       'email': None,
                                                       'first_name': 'John',
                                                       'id': 52,
                                                       'is_away': False,
                                                       'last_name': 'Smith',
                                                       'on_vacation': False,
                                                       'phone': '3055559999',
                                                       'return_date': None}]}},
 'agent_response_tracker': None,
 'conversation_id': 'kk2Yv36Y06B3owrc-XE3nQ',
 'is_quiet': False,
 'twilio_sid': '438c3875-4db7-4990-a1a1-2009a620d32b',  <--- **** THIS IS BETTER NOW ****
 'vonage_uuid': None}
````