### PR TITLE
extend transfer call to optionally pass the phone number dynamically

### DIFF
--- a/tests/streaming/action/test_transfer_call.py
+++ b/tests/streaming/action/test_transfer_call.py
@@ -9,7 +9,7 @@ from pytest_mock import MockerFixture
 from tests.fakedata.id import generate_uuid
 
 from vocode.streaming.action.transfer_call import (
-    TransferCallParameters,
+    TransferCallEmptyParameters,
     TransferCallVocodeActionConfig,
     TwilioTransferCall,
     VonageTransferCall,
@@ -95,7 +95,7 @@ async def test_twilio_transfer_call_succeeds(
     action_input = TwilioPhoneConversationActionInput(
         action_config=TransferCallVocodeActionConfig(phone_number=TRANSFER_PHONE_NUMBER),
         conversation_id=conversation_id,
-        params=TransferCallParameters(),
+        params=TransferCallEmptyParameters(),
         twilio_sid=twilio_sid,
         user_message_tracker=user_message_tracker,
     )
@@ -155,7 +155,7 @@ async def test_twilio_transfer_call_fails_if_interrupted(
     action_input = TwilioPhoneConversationActionInput(
         action_config=TransferCallVocodeActionConfig(phone_number=TRANSFER_PHONE_NUMBER),
         conversation_id=conversation_id,
-        params=TransferCallParameters(),
+        params=TransferCallEmptyParameters(),
         twilio_sid="twilio_sid",
         user_message_tracker=user_message_tracker,
     )
@@ -202,7 +202,7 @@ async def test_vonage_transfer_call_inbound(
         action_input = VonagePhoneConversationActionInput(
             action_config=TransferCallVocodeActionConfig(phone_number=transfer_phone_number),
             conversation_id=conversation_id,
-            params=TransferCallParameters(),
+            params=TransferCallEmptyParameters(),
             vonage_uuid=str(vonage_uuid),
             user_message_tracker=user_message_tracker,
         )


### PR DESCRIPTION
Allow the transfer call action to optionally accept phone_number as a parameter so the LLM can feed the TN to transfer to at runtime. If a TN is not passed, then you must pass via the action_config.