### PR TITLE
[DOW-113] deprecate output queue and manually attach workers to each other

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, vocode-core-0.1.0]
 
 jobs:
   build:

--- a/playground/streaming/agent/chat.py
+++ b/playground/streaming/agent/chat.py
@@ -158,6 +158,13 @@ async def run_agent(
                 break
 
     async def sender():
+        if agent.agent_config.initial_message is not None:
+            agent.agent_responses_consumer.consume_nonblocking(
+                InterruptibleAgentResponseEvent(
+                    payload=AgentResponseMessage(message=agent.agent_config.initial_message),
+                    agent_response_tracker=asyncio.Event(),
+                )
+            )
         while not ended:
             try:
                 message = await asyncio.get_event_loop().run_in_executor(
@@ -221,13 +228,6 @@ async def agent_main():
     )
     agent.attach_conversation_state_manager(DummyConversationManager())
     agent.attach_transcript(transcript)
-    if agent.agent_config.initial_message is not None:
-        agent.output_queue.put_nowait(
-            InterruptibleAgentResponseEvent(
-                payload=AgentResponseMessage(message=agent.agent_config.initial_message),
-                agent_response_tracker=asyncio.Event(),
-            )
-        )
     agent.start()
 
     try:

--- a/vocode/streaming/action/worker.py
+++ b/vocode/streaming/action/worker.py
@@ -12,6 +12,7 @@ from vocode.streaming.models.actions import (
 )
 from vocode.streaming.utils.state_manager import AbstractConversationStateManager
 from vocode.streaming.utils.worker import (
+    AbstractWorker,
     InterruptibleEvent,
     InterruptibleEventFactory,
     InterruptibleWorker,
@@ -19,16 +20,14 @@ from vocode.streaming.utils.worker import (
 
 
 class ActionsWorker(InterruptibleWorker):
+    consumer: AbstractWorker[InterruptibleEvent[ActionResultAgentInput]]
+
     def __init__(
         self,
         action_factory: AbstractActionFactory,
-        input_queue: asyncio.Queue[InterruptibleEvent[ActionInput]],
-        output_queue: asyncio.Queue[InterruptibleEvent[AgentInput]],
         interruptible_event_factory: InterruptibleEventFactory = InterruptibleEventFactory(),
     ):
         super().__init__(
-            input_queue=input_queue,
-            output_queue=output_queue,
             interruptible_event_factory=interruptible_event_factory,
         )
         self.action_factory = action_factory
@@ -43,22 +42,24 @@ class ActionsWorker(InterruptibleWorker):
         action = self.action_factory.create_action(action_input.action_config)
         action.attach_conversation_state_manager(self.conversation_state_manager)
         action_output = await action.run(action_input)
-        self.produce_interruptible_event_nonblocking(
-            ActionResultAgentInput(
-                conversation_id=action_input.conversation_id,
-                action_input=action_input,
-                action_output=action_output,
-                vonage_uuid=(
-                    action_input.vonage_uuid
-                    if isinstance(action_input, VonagePhoneConversationActionInput)
-                    else None
+        self.consumer.consume_nonblocking(
+            self.interruptible_event_factory.create_interruptible_event(
+                ActionResultAgentInput(
+                    conversation_id=action_input.conversation_id,
+                    action_input=action_input,
+                    action_output=action_output,
+                    vonage_uuid=(
+                        action_input.vonage_uuid
+                        if isinstance(action_input, VonagePhoneConversationActionInput)
+                        else None
+                    ),
+                    twilio_sid=(
+                        action_input.twilio_sid
+                        if isinstance(action_input, TwilioPhoneConversationActionInput)
+                        else None
+                    ),
+                    is_quiet=action.quiet,
                 ),
-                twilio_sid=(
-                    action_input.twilio_sid
-                    if isinstance(action_input, TwilioPhoneConversationActionInput)
-                    else None
-                ),
-                is_quiet=action.quiet,
-            ),
-            is_interruptible=False,
+                is_interruptible=False,
+            )
         )

--- a/vocode/streaming/output_device/blocking_speaker_output.py
+++ b/vocode/streaming/output_device/blocking_speaker_output.py
@@ -23,9 +23,8 @@ class BlockingSpeakerOutput(BaseOutputDevice, ThreadAsyncWorker):
         sampling_rate = sampling_rate or int(
             self.device_info.get("default_samplerate", self.DEFAULT_SAMPLING_RATE)
         )
-        self.input_queue: asyncio.Queue[bytes] = asyncio.Queue()
         BaseOutputDevice.__init__(self, sampling_rate, audio_encoding)
-        ThreadAsyncWorker.__init__(self, self.input_queue)
+        ThreadAsyncWorker.__init__(self)
         self.stream = sd.OutputStream(
             channels=1,
             samplerate=self.sampling_rate,
@@ -33,7 +32,7 @@ class BlockingSpeakerOutput(BaseOutputDevice, ThreadAsyncWorker):
             device=int(self.device_info["index"]),
         )
         self._ended = False
-        self.input_queue.put_nowait(self.sampling_rate * b"\x00")
+        self.consume_nonblocking(self.sampling_rate * b"\x00")
         self.stream.start()
 
     def start(self):

--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -63,11 +63,13 @@ from vocode.streaming.utils.events_manager import EventsManager
 from vocode.streaming.utils.speed_manager import SpeedManager
 from vocode.streaming.utils.state_manager import ConversationStateManager
 from vocode.streaming.utils.worker import (
+    AbstractWorker,
     AsyncQueueWorker,
     InterruptibleAgentResponseEvent,
     InterruptibleAgentResponseWorker,
     InterruptibleEvent,
     InterruptibleEventFactory,
+    InterruptibleWorker,
 )
 from vocode.utils.sentry_utils import (
     CustomSentrySpans,
@@ -140,16 +142,14 @@ class StreamingConversation(Generic[OutputDeviceType]):
         """Processes all transcriptions: sends an interrupt if needed
         and sends final transcriptions to the output queue"""
 
+        consumer: AbstractWorker[InterruptibleEvent[Transcription]]
+
         def __init__(
             self,
-            input_queue: asyncio.Queue[Transcription],
-            output_queue: asyncio.Queue[InterruptibleEvent[AgentInput]],
             conversation: "StreamingConversation",
             interruptible_event_factory: InterruptibleEventFactory,
         ):
-            super().__init__(input_queue, output_queue)
-            self.input_queue = input_queue
-            self.output_queue = output_queue
+            super().__init__()
             self.conversation = conversation
             self.interruptible_event_factory = interruptible_event_factory
             self.in_interrupt_endpointing_config = False
@@ -310,9 +310,9 @@ class StreamingConversation(Generic[OutputDeviceType]):
                         agent_response_tracker=agent_response_tracker,
                     ),
                 )
-                self.output_queue.put_nowait(event)
+                self.consumer.consume_nonblocking(event)
 
-    class FillerAudioWorker(InterruptibleAgentResponseWorker):
+    class FillerAudioWorker(InterruptibleWorker[InterruptibleAgentResponseEvent[FillerAudio]]):
         """
         - Waits for a configured number of seconds and then sends filler audio to the output
         - Exposes wait_for_filler_audio_to_finish() which the AgentResponsesWorker waits on before
@@ -321,11 +321,9 @@ class StreamingConversation(Generic[OutputDeviceType]):
 
         def __init__(
             self,
-            input_queue: asyncio.Queue[InterruptibleAgentResponseEvent[FillerAudio]],
             conversation: "StreamingConversation",
         ):
-            super().__init__(input_queue=input_queue)
-            self.input_queue = input_queue
+            super().__init__()
             self.conversation = conversation
             self.current_filler_seconds_per_chunk: Optional[int] = None
             self.filler_audio_started_event: Optional[threading.Event] = None
@@ -366,26 +364,21 @@ class StreamingConversation(Generic[OutputDeviceType]):
             except asyncio.CancelledError:
                 pass
 
-    class AgentResponsesWorker(InterruptibleAgentResponseWorker):
+    class AgentResponsesWorker(InterruptibleWorker[InterruptibleAgentResponseEvent[AgentResponse]]):
         """Runs Synthesizer.create_speech and sends the SynthesisResult to the output queue"""
+
+        consumer: AbstractWorker[
+            InterruptibleAgentResponseEvent[
+                Tuple[Union[BaseMessage, EndOfTurn], Optional[SynthesisResult]]
+            ]
+        ]
 
         def __init__(
             self,
-            input_queue: asyncio.Queue[InterruptibleAgentResponseEvent[AgentResponse]],
-            output_queue: asyncio.Queue[
-                InterruptibleAgentResponseEvent[
-                    Tuple[Union[BaseMessage, EndOfTurn], Optional[SynthesisResult]]
-                ]
-            ],
             conversation: "StreamingConversation",
             interruptible_event_factory: InterruptibleEventFactory,
         ):
-            super().__init__(
-                input_queue=input_queue,
-                output_queue=output_queue,
-            )
-            self.input_queue = input_queue
-            self.output_queue = output_queue
+            super().__init__()
             self.conversation = conversation
             self.interruptible_event_factory = interruptible_event_factory
             self.chunk_size = self.conversation._get_synthesizer_chunk_size()
@@ -434,10 +427,12 @@ class StreamingConversation(Generic[OutputDeviceType]):
                     logger.debug("Sending end of turn")
                     if isinstance(self.conversation.synthesizer, InputStreamingSynthesizer):
                         await self.conversation.synthesizer.handle_end_of_turn()
-                    self.produce_interruptible_agent_response_event_nonblocking(
-                        (agent_response_message.message, None),
-                        is_interruptible=item.is_interruptible,
-                        agent_response_tracker=item.agent_response_tracker,
+                    self.consumer.consume_nonblocking(
+                        self.interruptible_event_factory.create_interruptible_agent_response_event(
+                            (agent_response_message.message, None),
+                            is_interruptible=item.is_interruptible,
+                            agent_response_tracker=item.agent_response_tracker,
+                        ),
                     )
                     self.is_first_text_chunk = True
                     return
@@ -504,10 +499,12 @@ class StreamingConversation(Generic[OutputDeviceType]):
                     if not synthesis_result.cached and synthesis_span:
                         synthesis_result.synthesis_total_span = synthesis_span
                         synthesis_result.ttft_span = ttft_span
-                    self.produce_interruptible_agent_response_event_nonblocking(
-                        (agent_response_message.message, synthesis_result),
-                        is_interruptible=item.is_interruptible,
-                        agent_response_tracker=item.agent_response_tracker,
+                    self.consumer.consume_nonblocking(
+                        self.interruptible_event_factory.create_interruptible_agent_response_event(
+                            (agent_response_message.message, synthesis_result),
+                            is_interruptible=item.is_interruptible,
+                            agent_response_tracker=item.agent_response_tracker,
+                        ),
                     )
                 self.last_agent_response_tracker = item.agent_response_tracker
                 if not isinstance(agent_response_message.message, SilenceMessage):
@@ -515,20 +512,20 @@ class StreamingConversation(Generic[OutputDeviceType]):
             except asyncio.CancelledError:
                 pass
 
-    class SynthesisResultsWorker(InterruptibleAgentResponseWorker):
+    class SynthesisResultsWorker(
+        InterruptibleWorker[
+            InterruptibleAgentResponseEvent[
+                Tuple[Union[BaseMessage, EndOfTurn], Optional[SynthesisResult]]
+            ]
+        ]
+    ):
         """Plays SynthesisResults from the output queue on the output device"""
 
         def __init__(
             self,
-            input_queue: asyncio.Queue[
-                InterruptibleAgentResponseEvent[
-                    Tuple[Union[BaseMessage, EndOfTurn], Optional[SynthesisResult]]
-                ]
-            ],
             conversation: "StreamingConversation",
         ):
-            super().__init__(input_queue=input_queue)
-            self.input_queue = input_queue
+            super().__init__()
             self.conversation = conversation
             self.last_transcript_message: Optional[Message] = None
 
@@ -602,49 +599,52 @@ class StreamingConversation(Generic[OutputDeviceType]):
 
         self.interruptible_events: queue.Queue[InterruptibleEvent] = queue.Queue()
         self.interruptible_event_factory = self.QueueingInterruptibleEventFactory(conversation=self)
-        self.agent.set_interruptible_event_factory(self.interruptible_event_factory)
         self.synthesis_results_queue: asyncio.Queue[
             InterruptibleAgentResponseEvent[
                 Tuple[Union[BaseMessage, EndOfTurn], Optional[SynthesisResult]]
             ]
         ] = asyncio.Queue()
-        self.filler_audio_queue: asyncio.Queue[InterruptibleAgentResponseEvent[FillerAudio]] = (
-            asyncio.Queue()
-        )
         self.state_manager = self.create_state_manager()
+
+        # Transcriptions Worker
         self.transcriptions_worker = self.TranscriptionsWorker(
-            input_queue=self.transcriber.output_queue,
-            output_queue=self.agent.get_input_queue(),
             conversation=self,
             interruptible_event_factory=self.interruptible_event_factory,
         )
+        self.transcriber.consumer = self.transcriptions_worker
+
+        # Agent
+        self.transcriptions_worker.consumer = self.agent
+        self.agent.set_interruptible_event_factory(self.interruptible_event_factory)
         self.agent.attach_conversation_state_manager(self.state_manager)
+
+        # Agent Responses Worker
         self.agent_responses_worker = self.AgentResponsesWorker(
-            input_queue=self.agent.get_output_queue(),
-            output_queue=self.synthesis_results_queue,
             conversation=self,
             interruptible_event_factory=self.interruptible_event_factory,
         )
+        self.agent.agent_responses_consumer = self.agent_responses_worker
+
+        # Actions Worker
         self.actions_worker = None
         if self.agent.get_agent_config().actions:
             self.actions_worker = ActionsWorker(
-                input_queue=self.agent.actions_queue,
-                output_queue=self.agent.get_input_queue(),
-                interruptible_event_factory=self.interruptible_event_factory,
                 action_factory=self.agent.action_factory,
+                interruptible_event_factory=self.interruptible_event_factory,
             )
             self.actions_worker.attach_conversation_state_manager(self.state_manager)
-        self.synthesis_results_worker = self.SynthesisResultsWorker(
-            input_queue=self.synthesis_results_queue,
-            conversation=self,
-        )
+            self.actions_worker.consumer = self.agent
+            self.agent.actions_consumer = self.actions_worker
+
+        # Synthesis Results Worker
+        self.synthesis_results_worker = self.SynthesisResultsWorker(conversation=self)
+        self.agent_responses_worker.consumer = self.synthesis_results_worker
+
+        # Filler Audio Worker
         self.filler_audio_worker = None
         self.filler_audio_config: Optional[FillerAudioConfig] = None
         if self.agent.get_agent_config().send_filler_audio:
-            self.filler_audio_worker = self.FillerAudioWorker(
-                input_queue=self.filler_audio_queue,
-                conversation=self,
-            )
+            self.filler_audio_worker = self.FillerAudioWorker(conversation=self)
 
         self.speed_coefficient = speed_coefficient
         self.speed_manager = SpeedManager(

--- a/vocode/streaming/synthesizer/base_synthesizer.py
+++ b/vocode/streaming/synthesizer/base_synthesizer.py
@@ -22,6 +22,7 @@ from vocode.streaming.telephony.constants import MULAW_SILENCE_BYTE, PCM_SILENCE
 from vocode.streaming.utils import convert_wav, get_chunk_size_per_second
 from vocode.streaming.utils.async_requester import AsyncRequestor
 from vocode.streaming.utils.create_task import asyncio_create_task_with_done_error_log
+from vocode.streaming.utils.worker import QueueConsumer
 
 FILLER_PHRASES = [
     BaseMessage(text="Um..."),
@@ -396,14 +397,12 @@ class BaseSynthesizer(Generic[SynthesizerConfigType]):
         response: aiohttp.ClientResponse,
         chunk_size: int,
     ) -> AsyncGenerator[SynthesisResult.ChunkResult, None]:
-        miniaudio_worker_input_queue: asyncio.Queue[Union[bytes, None]] = asyncio.Queue()
-        miniaudio_worker_output_queue: asyncio.Queue[Tuple[bytes, bool]] = asyncio.Queue()
+        miniaudio_worker_consumer: QueueConsumer = QueueConsumer()
         miniaudio_worker = MiniaudioWorker(
             self.synthesizer_config,
             chunk_size,
-            miniaudio_worker_input_queue,
-            miniaudio_worker_output_queue,
         )
+        miniaudio_worker.consumer = miniaudio_worker_consumer
         miniaudio_worker.start()
         stream_reader = response.content
 
@@ -419,7 +418,7 @@ class BaseSynthesizer(Generic[SynthesizerConfigType]):
             # Await the output queue of the MiniaudioWorker and yield the wav chunks in another loop
             while True:
                 # Get the wav chunk and the flag from the output queue of the MiniaudioWorker
-                wav_chunk, is_last = await miniaudio_worker.output_queue.get()
+                wav_chunk, is_last = await miniaudio_worker_consumer.input_queue.get()
                 if self.synthesizer_config.should_encode_as_wav:
                     wav_chunk = encode_as_wav(wav_chunk, self.synthesizer_config)
 

--- a/vocode/streaming/synthesizer/miniaudio_worker.py
+++ b/vocode/streaming/synthesizer/miniaudio_worker.py
@@ -10,22 +10,38 @@ from loguru import logger
 from vocode.streaming.models.synthesizer import SynthesizerConfig
 from vocode.streaming.utils import convert_wav
 from vocode.streaming.utils.mp3_helper import decode_mp3
-from vocode.streaming.utils.worker import ThreadAsyncWorker
+from vocode.streaming.utils.worker import AbstractWorker, ThreadAsyncWorker
 
 
 class MiniaudioWorker(ThreadAsyncWorker[Union[bytes, None]]):
+    consumer: AbstractWorker[Tuple[bytes, bool]]
+
     def __init__(
         self,
         synthesizer_config: SynthesizerConfig,
         chunk_size: int,
-        input_queue: asyncio.Queue[Union[bytes, None]],
-        output_queue: asyncio.Queue[Tuple[bytes, bool]],
     ) -> None:
-        super().__init__(input_queue, output_queue)
-        self.output_queue = output_queue  # for typing
+        super().__init__()
         self.synthesizer_config = synthesizer_config
         self.chunk_size = chunk_size
         self._ended = False
+
+    async def run_thread_forwarding(self):
+        try:
+            await asyncio.gather(
+                self._forward_to_thread(),
+                self._forward_from_thread(),
+            )
+        except asyncio.CancelledError:
+            return
+
+    async def _forward_from_thread(self):
+        while True:
+            try:
+                chunk, done = await self.output_janus_queue.async_q.get()
+                self.consumer.consume_nonblocking((chunk, done))
+            except asyncio.CancelledError:
+                break
 
     def _run_loop(self):
         # tracks the mp3 so far

--- a/vocode/streaming/telephony/conversation/abstract_phone_conversation.py
+++ b/vocode/streaming/telephony/conversation/abstract_phone_conversation.py
@@ -68,12 +68,6 @@ class AbstractPhoneConversation(StreamingConversation[TelephonyOutputDeviceType]
             events_manager=events_manager,
             speed_coefficient=speed_coefficient,
         )
-        self.transcriptions_worker = self.TranscriptionsWorker(
-            input_queue=self.transcriber.output_queue,
-            output_queue=self.agent.get_input_queue(),
-            conversation=self,
-            interruptible_event_factory=self.interruptible_event_factory,
-        )
         self.config_manager = config_manager
 
     def attach_ws(self, ws: WebSocket):

--- a/vocode/streaming/transcriber/assembly_ai_transcriber.py
+++ b/vocode/streaming/transcriber/assembly_ai_transcriber.py
@@ -75,7 +75,7 @@ class AssemblyAITranscriber(BaseAsyncTranscriber[AssemblyAITranscriberConfig]):
         if (
             len(self.buffer) / (2 * self.transcriber_config.sampling_rate)
         ) >= self.transcriber_config.buffer_size_seconds:
-            self.input_queue.put_nowait(self.buffer)
+            self.consume_nonblocking(self.buffer)
             self.buffer = bytearray()
 
     def terminate(self):
@@ -133,7 +133,7 @@ class AssemblyAITranscriber(BaseAsyncTranscriber[AssemblyAITranscriberConfig]):
                     is_final = "message_type" in data and data["message_type"] == "FinalTranscript"
 
                     if "text" in data and data["text"]:
-                        self.output_queue.put_nowait(
+                        self.produce_nonblocking(
                             Transcription(
                                 message=data["text"],
                                 confidence=data["confidence"],

--- a/vocode/streaming/transcriber/azure_transcriber.py
+++ b/vocode/streaming/transcriber/azure_transcriber.py
@@ -79,12 +79,12 @@ class AzureTranscriber(BaseThreadAsyncTranscriber[AzureTranscriberConfig]):
             op=CustomSentrySpans.LATENCY_OF_CONVERSATION,
             start_timestamp=datetime.now(tz=timezone.utc),
         )
-        self.output_janus_queue.sync_q.put_nowait(
+        self.produce_nonblocking(
             Transcription(message=evt.result.text, confidence=1.0, is_final=True)
         )
 
     def recognized_sentence_stream(self, evt):
-        self.output_janus_queue.sync_q.put_nowait(
+        self.produce_nonblocking(
             Transcription(message=evt.result.text, confidence=1.0, is_final=False)
         )
 

--- a/vocode/streaming/transcriber/base_transcriber.py
+++ b/vocode/streaming/transcriber/base_transcriber.py
@@ -8,18 +8,19 @@ from typing import Generic, Optional, TypeVar, Union
 from vocode.streaming.models.audio import AudioEncoding
 from vocode.streaming.models.transcriber import TranscriberConfig, Transcription
 from vocode.streaming.utils.speed_manager import SpeedManager
-from vocode.streaming.utils.worker import AsyncWorker, ThreadAsyncWorker
+from vocode.streaming.utils.worker import AbstractWorker, AsyncWorker, ThreadAsyncWorker
 
 TranscriberConfigType = TypeVar("TranscriberConfigType", bound=TranscriberConfig)
 
 
-class AbstractTranscriber(Generic[TranscriberConfigType], ABC):
+class AbstractTranscriber(Generic[TranscriberConfigType], AbstractWorker[bytes]):
+    consumer: AbstractWorker[Transcription]
+
     def __init__(self, transcriber_config: TranscriberConfigType):
+        AbstractWorker.__init__(self)
         self.transcriber_config = transcriber_config
         self.is_muted = False
         self.speed_manager: Optional[SpeedManager] = None
-        self.input_queue: asyncio.Queue[bytes] = asyncio.Queue()
-        self.output_queue: asyncio.Queue[Transcription] = asyncio.Queue()
 
     def attach_speed_manager(self, speed_manager: SpeedManager):
         self.speed_manager = speed_manager
@@ -47,11 +48,14 @@ class AbstractTranscriber(Generic[TranscriberConfigType], ABC):
     async def _run_loop(self):
         pass
 
-    def send_audio(self, chunk):
+    def send_audio(self, chunk: bytes):
         if not self.is_muted:
             self.consume_nonblocking(chunk)
         else:
             self.consume_nonblocking(self.create_silent_chunk(len(chunk)))
+
+    def produce_nonblocking(self, item: Transcription):
+        self.consumer.consume_nonblocking(item)
 
     @abstractmethod
     def terminate(self):
@@ -61,7 +65,7 @@ class AbstractTranscriber(Generic[TranscriberConfigType], ABC):
 class BaseAsyncTranscriber(AbstractTranscriber[TranscriberConfigType], AsyncWorker):
     def __init__(self, transcriber_config: TranscriberConfigType):
         AbstractTranscriber.__init__(self, transcriber_config)
-        AsyncWorker.__init__(self, self.input_queue, self.output_queue)
+        AsyncWorker.__init__(self)
 
     async def _run_loop(self):
         raise NotImplementedError
@@ -73,10 +77,30 @@ class BaseAsyncTranscriber(AbstractTranscriber[TranscriberConfigType], AsyncWork
 class BaseThreadAsyncTranscriber(AbstractTranscriber[TranscriberConfigType], ThreadAsyncWorker):
     def __init__(self, transcriber_config: TranscriberConfigType):
         AbstractTranscriber.__init__(self, transcriber_config)
-        ThreadAsyncWorker.__init__(self, self.input_queue, self.output_queue)
+        ThreadAsyncWorker.__init__(self)
 
     def _run_loop(self):
         raise NotImplementedError
+
+    async def run_thread_forwarding(self):
+        try:
+            await asyncio.gather(
+                self._forward_to_thread(),
+                self._forward_from_thread(),
+            )
+        except asyncio.CancelledError:
+            return
+
+    async def _forward_from_thread(self):
+        while True:
+            try:
+                transcription = await self.output_janus_queue.async_q.get()
+                self.consumer.consume_nonblocking(transcription)
+            except asyncio.CancelledError:
+                break
+
+    def produce_nonblocking(self, item: Transcription):
+        self.output_janus_queue.sync_q.put_nowait(item)
 
     def terminate(self):
         ThreadAsyncWorker.terminate(self)

--- a/vocode/streaming/transcriber/deepgram_transcriber.py
+++ b/vocode/streaming/transcriber/deepgram_transcriber.py
@@ -190,7 +190,7 @@ class DeepgramTranscriber(BaseAsyncTranscriber[DeepgramTranscriberConfig]):
             },
         )
         terminate_msg = json.dumps({"type": "CloseStream"}).encode("utf-8")
-        self.input_queue.put_nowait(terminate_msg)
+        self.consume_nonblocking(terminate_msg)  # todo (dow-107): typing
         self._ended = True
         super().terminate()
 
@@ -485,7 +485,7 @@ class DeepgramTranscriber(BaseAsyncTranscriber[DeepgramTranscriberConfig]):
                                 is_final_ts=is_final_ts,
                                 output_ts=output_ts,
                             )
-                            self.output_queue.put_nowait(
+                            self.produce_nonblocking(
                                 Transcription(
                                     message=buffer,
                                     confidence=buffer_avg_confidence,
@@ -513,7 +513,7 @@ class DeepgramTranscriber(BaseAsyncTranscriber[DeepgramTranscriberConfig]):
                                 else:
                                     interim_message = buffer
 
-                                self.output_queue.put_nowait(
+                                self.produce_nonblocking(
                                     Transcription(
                                         message=interim_message,
                                         confidence=deepgram_response.top_choice.confidence,

--- a/vocode/streaming/transcriber/gladia_transcriber.py
+++ b/vocode/streaming/transcriber/gladia_transcriber.py
@@ -53,7 +53,7 @@ class GladiaTranscriber(BaseAsyncTranscriber[GladiaTranscriberConfig]):
         if (
             len(self.buffer) / (2 * self.transcriber_config.sampling_rate)
         ) >= self.transcriber_config.buffer_size_seconds:
-            self.input_queue.put_nowait(self.buffer)
+            self.consume_nonblocking(self.buffer)
             self.buffer = bytearray()
 
     def terminate(self):
@@ -104,7 +104,7 @@ class GladiaTranscriber(BaseAsyncTranscriber[GladiaTranscriberConfig]):
                         is_final = data["type"] == "final"
 
                         if "transcription" in data and data["transcription"]:
-                            self.output_queue.put_nowait(
+                            self.produce_nonblocking(
                                 Transcription(
                                     message=data["transcription"],
                                     confidence=data["confidence"],

--- a/vocode/streaming/transcriber/google_transcriber.py
+++ b/vocode/streaming/transcriber/google_transcriber.py
@@ -80,7 +80,7 @@ class GoogleTranscriber(BaseThreadAsyncTranscriber[GoogleTranscriberConfig]):
         message = top_choice.transcript
         confidence = top_choice.confidence
 
-        self.output_janus_queue.sync_q.put_nowait(
+        self.produce_nonblocking(
             Transcription(message=message, confidence=confidence, is_final=result.is_final)
         )
 

--- a/vocode/streaming/transcriber/rev_ai_transcriber.py
+++ b/vocode/streaming/transcriber/rev_ai_transcriber.py
@@ -118,12 +118,12 @@ class RevAITranscriber(BaseAsyncTranscriber[RevAITranscriberConfig]):
 
                     confidence = 1.0
                     if is_done:
-                        self.output_queue.put_nowait(
+                        self.produce_nonblocking(
                             Transcription(message=buffer, confidence=confidence, is_final=True)
                         )
                         buffer = ""
                     else:
-                        self.output_queue.put_nowait(
+                        self.produce_nonblocking(
                             Transcription(
                                 message=buffer,
                                 confidence=confidence,
@@ -137,5 +137,5 @@ class RevAITranscriber(BaseAsyncTranscriber[RevAITranscriberConfig]):
 
     def terminate(self):
         terminate_msg = json.dumps({"type": "CloseStream"})
-        self.input_queue.put_nowait(terminate_msg)
+        self.consume_nonblocking(terminate_msg)
         self.closed = True

--- a/vocode/streaming/transcriber/whisper_cpp_transcriber.py
+++ b/vocode/streaming/transcriber/whisper_cpp_transcriber.py
@@ -72,7 +72,7 @@ class WhisperCPPTranscriber(BaseThreadAsyncTranscriber[WhisperCPPTranscriberConf
                 message_buffer += message
                 is_final = any(message_buffer.endswith(ending) for ending in SENTENCE_ENDINGS)
                 in_memory_wav, audio_buffer = self.create_new_buffer()
-                self.output_queue.put_nowait(
+                self.produce_nonblocking(
                     Transcription(message=message_buffer, confidence=confidence, is_final=is_final)
                 )
                 if is_final:

--- a/vocode/streaming/utils/worker.py
+++ b/vocode/streaming/utils/worker.py
@@ -29,7 +29,7 @@ class AbstractWorker(Generic[WorkerInputType], ABC):
 class QueueConsumer(AbstractWorker[WorkerInputType]):
     def __init__(
         self,
-        input_queue: asyncio.Queue[WorkerInputType] = None,
+        input_queue: Optional[asyncio.Queue[WorkerInputType]] = None,
     ) -> None:
         self.input_queue: asyncio.Queue[WorkerInputType] = input_queue or asyncio.Queue()
 

--- a/vocode/streaming/utils/worker.py
+++ b/vocode/streaming/utils/worker.py
@@ -29,8 +29,9 @@ class AbstractWorker(Generic[WorkerInputType], ABC):
 class QueueConsumer(AbstractWorker[WorkerInputType]):
     def __init__(
         self,
+        input_queue: asyncio.Queue[WorkerInputType] = None,
     ) -> None:
-        self.input_queue: asyncio.Queue[WorkerInputType] = asyncio.Queue()
+        self.input_queue: asyncio.Queue[WorkerInputType] = input_queue or asyncio.Queue()
 
     def consume_nonblocking(self, item: WorkerInputType):
         self.input_queue.put_nowait(item)

--- a/vocode/streaming/utils/worker.py
+++ b/vocode/streaming/utils/worker.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 import asyncio
 import threading
-from typing import Any, Generic, Optional, TypeVar
+from typing import Any, Dict, Generic, List, Optional, TypeVar
 
 import janus
 from loguru import logger
@@ -12,15 +13,38 @@ from vocode.streaming.utils.create_task import asyncio_create_task_with_done_err
 WorkerInputType = TypeVar("WorkerInputType")
 
 
-class AsyncWorker(Generic[WorkerInputType]):
+class AbstractWorker(Generic[WorkerInputType], ABC):
+    @abstractmethod
+    def start(self):
+        raise NotImplementedError
+
+    @abstractmethod
+    def consume_nonblocking(self, item: WorkerInputType):
+        raise NotImplementedError
+
+    def terminate(self):
+        pass
+
+
+class QueueConsumer(AbstractWorker[WorkerInputType]):
     def __init__(
         self,
-        input_queue: asyncio.Queue,
-        output_queue: asyncio.Queue = asyncio.Queue(),
+    ) -> None:
+        self.input_queue: asyncio.Queue[WorkerInputType] = asyncio.Queue()
+
+    def consume_nonblocking(self, item: WorkerInputType):
+        self.input_queue.put_nowait(item)
+
+    def start(self):
+        pass
+
+
+class AsyncWorker(AbstractWorker[WorkerInputType]):
+    def __init__(
+        self,
     ) -> None:
         self.worker_task: Optional[asyncio.Task] = None
-        self.input_queue = input_queue
-        self.output_queue = output_queue
+        self.input_queue: asyncio.Queue[WorkerInputType] = asyncio.Queue()
 
     def start(self) -> asyncio.Task:
         self.worker_task = asyncio_create_task_with_done_error_log(
@@ -32,9 +56,6 @@ class AsyncWorker(Generic[WorkerInputType]):
 
     def consume_nonblocking(self, item: WorkerInputType):
         self.input_queue.put_nowait(item)
-
-    def produce_nonblocking(self, item):
-        self.output_queue.put_nowait(item)
 
     async def _run_loop(self):
         raise NotImplementedError
@@ -49,10 +70,8 @@ class AsyncWorker(Generic[WorkerInputType]):
 class ThreadAsyncWorker(AsyncWorker[WorkerInputType]):
     def __init__(
         self,
-        input_queue: asyncio.Queue[WorkerInputType],
-        output_queue: asyncio.Queue = asyncio.Queue(),
     ) -> None:
-        super().__init__(input_queue, output_queue)
+        super().__init__()
         self.worker_thread: Optional[threading.Thread] = None
         self.input_janus_queue: janus.Queue[WorkerInputType] = janus.Queue()
         self.output_janus_queue: janus.Queue = janus.Queue()
@@ -69,10 +88,7 @@ class ThreadAsyncWorker(AsyncWorker[WorkerInputType]):
 
     async def run_thread_forwarding(self):
         try:
-            await asyncio.gather(
-                self._forward_to_thread(),
-                self._forward_from_thead(),
-            )
+            await self._forward_to_thread()
         except asyncio.CancelledError:
             return
 
@@ -81,16 +97,8 @@ class ThreadAsyncWorker(AsyncWorker[WorkerInputType]):
             item = await self.input_queue.get()
             self.input_janus_queue.async_q.put_nowait(item)
 
-    async def _forward_from_thead(self):
-        while True:
-            item = await self.output_janus_queue.async_q.get()
-            self.output_queue.put_nowait(item)
-
     def _run_loop(self):
         raise NotImplementedError
-
-    def terminate(self):
-        return super().terminate()
 
 
 class AsyncQueueWorker(AsyncWorker):
@@ -180,38 +188,14 @@ InterruptibleEventType = TypeVar("InterruptibleEventType", bound=InterruptibleEv
 class InterruptibleWorker(AsyncWorker[InterruptibleEventType]):
     def __init__(
         self,
-        input_queue: asyncio.Queue[InterruptibleEventType],
-        output_queue: asyncio.Queue = asyncio.Queue(),
         interruptible_event_factory: InterruptibleEventFactory = InterruptibleEventFactory(),
         max_concurrency=2,
     ) -> None:
-        super().__init__(input_queue, output_queue)
-        self.input_queue = input_queue
+        super().__init__()
         self.max_concurrency = max_concurrency
         self.interruptible_event_factory = interruptible_event_factory
         self.current_task = None
         self.interruptible_event = None
-
-    def produce_interruptible_event_nonblocking(self, item: Any, is_interruptible: bool = True):
-        interruptible_event = self.interruptible_event_factory.create_interruptible_event(
-            item, is_interruptible=is_interruptible
-        )
-        return super().produce_nonblocking(interruptible_event)
-
-    def produce_interruptible_agent_response_event_nonblocking(
-        self,
-        item: Any,
-        is_interruptible: bool = True,
-        agent_response_tracker: Optional[asyncio.Event] = None,
-    ):
-        interruptible_utterance_event = (
-            self.interruptible_event_factory.create_interruptible_agent_response_event(
-                item,
-                is_interruptible=is_interruptible,
-                agent_response_tracker=agent_response_tracker or asyncio.Event(),
-            )
-        )
-        return super().produce_nonblocking(interruptible_utterance_event)
 
     async def _run_loop(self):
         # TODO Implement concurrency with max_nb_of_thread


### PR DESCRIPTION
workers were created rather haphazardly - really, we should interact with workers via `consume_nonblocking` and workers should decide how to process these events.

this PR:
- introduces `AbstractWorker`
- removes the notion of `output_queue` within workers and connects workers by setting up consumer types as below:

```
class MyWorker(AbstractWorker[WorkerInputType]):
  consumer_1: AbstractWorker[OutputType1]
  consumer_2: AbstractWorker[OutputType2]
```