### PR TITLE
feat: Add ability to configure OpenAI base URL in ChatGPTAgentConfig

### DIFF
--- a/tests/streaming/agent/test_base_agent.py
+++ b/tests/streaming/agent/test_base_agent.py
@@ -177,3 +177,16 @@ async def test_action_response_agent_input(mocker: MockerFixture):
     # TODO: assert that the canned response is optionally sent if the action is not quiet
     # and that it goes through the normal flow when the action is not quiet
     pass
+
+@pytest.fixture
+def agent_config():
+    return ChatGPTAgentConfig(
+        openai_api_key="test_key",
+        model_name="llama3-8b-8192",
+        base_url="https://api.groq.com/openai/v1",
+        prompt_preamble="Test prompt",
+    )
+
+def test_chat_gpt_agent_base_url(agent_config):
+    agent = ChatGPTAgent(agent_config)
+    assert agent.openai_client.base_url == "https://api.groq.com/openai/v1"

--- a/tests/streaming/agent/test_base_agent.py
+++ b/tests/streaming/agent/test_base_agent.py
@@ -183,7 +183,7 @@ def agent_config():
     return ChatGPTAgentConfig(
         openai_api_key="test_key",
         model_name="llama3-8b-8192",
-        base_url="https://api.groq.com/openai/v1",
+        base_url_override="https://api.groq.com/openai/v1",
         prompt_preamble="Test prompt",
     )
 

--- a/tests/streaming/agent/test_base_agent.py
+++ b/tests/streaming/agent/test_base_agent.py
@@ -178,15 +178,17 @@ async def test_action_response_agent_input(mocker: MockerFixture):
     # and that it goes through the normal flow when the action is not quiet
     pass
 
+
 @pytest.fixture
 def agent_config():
     return ChatGPTAgentConfig(
         openai_api_key="test_key",
         model_name="llama3-8b-8192",
-        base_url_override="https://api.groq.com/openai/v1",
+        base_url_override="https://api.groq.com/openai/v1/",
         prompt_preamble="Test prompt",
     )
 
+
 def test_chat_gpt_agent_base_url(agent_config):
     agent = ChatGPTAgent(agent_config)
-    assert str(agent.openai_client.base_url) == "https://api.groq.com/openai/v1"
+    assert str(agent.openai_client.base_url) == "https://api.groq.com/openai/v1/"

--- a/tests/streaming/agent/test_base_agent.py
+++ b/tests/streaming/agent/test_base_agent.py
@@ -189,4 +189,4 @@ def agent_config():
 
 def test_chat_gpt_agent_base_url(agent_config):
     agent = ChatGPTAgent(agent_config)
-    assert agent.openai_client.base_url == "https://api.groq.com/openai/v1"
+    assert str(agent.openai_client.base_url) == "https://api.groq.com/openai/v1"

--- a/vocode/streaming/agent/chat_gpt_agent.py
+++ b/vocode/streaming/agent/chat_gpt_agent.py
@@ -40,7 +40,7 @@ def instantiate_openai_client(agent_config: ChatGPTAgentConfig, model_fallback: 
         if agent_config.openai_api_key is not None:
             logger.info("Using OpenAI API key override")
         if agent_config.base_url_override is not None:
-            logger.info(f"Using OpenAI base URL override: {agent_config.base_url}")
+            logger.info(f"Using OpenAI base URL override: {agent_config.base_url_override}")
         return AsyncOpenAI(
             api_key=agent_config.openai_api_key or os.environ["OPENAI_API_KEY"],
             base_url=agent_config.base_url_override or "https://api.openai.com/v1",

--- a/vocode/streaming/agent/chat_gpt_agent.py
+++ b/vocode/streaming/agent/chat_gpt_agent.py
@@ -39,6 +39,8 @@ def instantiate_openai_client(agent_config: ChatGPTAgentConfig, model_fallback: 
     else:
         if agent_config.openai_api_key is not None:
             logger.info("Using OpenAI API key override")
+        if agent_config.base_url is not None:
+            logger.info(f"Using OpenAI base URL override: {agent_config.base_url}")
         return AsyncOpenAI(
             api_key=agent_config.openai_api_key or os.environ["OPENAI_API_KEY"],
             base_url=agent_config.base_url or "https://api.openai.com/v1",

--- a/vocode/streaming/agent/chat_gpt_agent.py
+++ b/vocode/streaming/agent/chat_gpt_agent.py
@@ -39,7 +39,7 @@ def instantiate_openai_client(agent_config: ChatGPTAgentConfig, model_fallback: 
     else:
         if agent_config.openai_api_key is not None:
             logger.info("Using OpenAI API key override")
-        if agent_config.base_url is not None:
+        if agent_config.base_url_override is not None:
             logger.info(f"Using OpenAI base URL override: {agent_config.base_url}")
         return AsyncOpenAI(
             api_key=agent_config.openai_api_key or os.environ["OPENAI_API_KEY"],

--- a/vocode/streaming/agent/chat_gpt_agent.py
+++ b/vocode/streaming/agent/chat_gpt_agent.py
@@ -41,7 +41,7 @@ def instantiate_openai_client(agent_config: ChatGPTAgentConfig, model_fallback: 
             logger.info("Using OpenAI API key override")
         return AsyncOpenAI(
             api_key=agent_config.openai_api_key or os.environ["OPENAI_API_KEY"],
-            base_url="https://api.openai.com/v1",
+            base_url=agent_config.base_url or "https://api.openai.com/v1",
             max_retries=0 if model_fallback else OPENAI_DEFAULT_MAX_RETRIES,
         )
 

--- a/vocode/streaming/agent/chat_gpt_agent.py
+++ b/vocode/streaming/agent/chat_gpt_agent.py
@@ -43,7 +43,7 @@ def instantiate_openai_client(agent_config: ChatGPTAgentConfig, model_fallback: 
             logger.info(f"Using OpenAI base URL override: {agent_config.base_url}")
         return AsyncOpenAI(
             api_key=agent_config.openai_api_key or os.environ["OPENAI_API_KEY"],
-            base_url=agent_config.base_url or "https://api.openai.com/v1",
+            base_url=agent_config.base_url_override or "https://api.openai.com/v1",
             max_retries=0 if model_fallback else OPENAI_DEFAULT_MAX_RETRIES,
         )
 

--- a/vocode/streaming/agent/token_utils.py
+++ b/vocode/streaming/agent/token_utils.py
@@ -258,4 +258,3 @@ def _format_func_into_prompt_str(func) -> str:
         result += "_: " + formatted
     result += ") => any;\n\n"
     return result
-

--- a/vocode/streaming/agent/token_utils.py
+++ b/vocode/streaming/agent/token_utils.py
@@ -90,7 +90,7 @@ def get_tokenizer_info(model: str) -> Optional[TokenizerInfo]:
     try:
         encoding = tiktoken.encoding_for_model(model)
     except KeyError:
-        logger.warning("Warning: model not found. Using cl100k_base encoding.")
+        logger.warning(f"Warning: model not found. Using cl100k_base encoding for {model}.")
         encoding = tiktoken.get_encoding("cl100k_base")
     if model in {
         "gpt-3.5-turbo-0613",
@@ -114,6 +114,14 @@ def get_tokenizer_info(model: str) -> Optional[TokenizerInfo]:
     elif "gpt-4" in model:
         logger.debug(
             "Warning: gpt-4 may update over time. Returning num tokens assuming gpt-4-0613."
+        )
+        tokens_per_message = 3
+        tokens_per_name = 1
+    elif "llama" in model.lower():
+        logger.warning(
+            f"Warning: you are using a llama model with an OpenAI compatible endpoint. \
+            Llama models are not supported natively support for token counting in tiktoken. \
+            Using cl100k_base encoding for {model} as an APPROXIMATION of token usage."
         )
         tokens_per_message = 3
         tokens_per_name = 1
@@ -250,3 +258,4 @@ def _format_func_into_prompt_str(func) -> str:
         result += "_: " + formatted
     result += ") => any;\n\n"
     return result
+

--- a/vocode/streaming/models/agent.py
+++ b/vocode/streaming/models/agent.py
@@ -115,6 +115,7 @@ class ChatGPTAgentConfig(AgentConfig, type=AgentType.CHAT_GPT.value):  # type: i
     openai_api_key: Optional[str] = None
     prompt_preamble: str
     model_name: str = CHAT_GPT_AGENT_DEFAULT_MODEL_NAME
+    base_url: Optional[str] = None
     temperature: float = LLM_AGENT_DEFAULT_TEMPERATURE
     max_tokens: int = LLM_AGENT_DEFAULT_MAX_TOKENS
     azure_params: Optional[AzureOpenAIConfig] = None

--- a/vocode/streaming/models/agent.py
+++ b/vocode/streaming/models/agent.py
@@ -115,7 +115,7 @@ class ChatGPTAgentConfig(AgentConfig, type=AgentType.CHAT_GPT.value):  # type: i
     openai_api_key: Optional[str] = None
     prompt_preamble: str
     model_name: str = CHAT_GPT_AGENT_DEFAULT_MODEL_NAME
-    base_url: Optional[str] = None
+    base_url_override: Optional[str] = None
     temperature: float = LLM_AGENT_DEFAULT_TEMPERATURE
     max_tokens: int = LLM_AGENT_DEFAULT_MAX_TOKENS
     azure_params: Optional[AzureOpenAIConfig] = None


### PR DESCRIPTION
## Motivation

To allow for extremely low latency interactions over voice with LLMs, Groq currently has the highest throughput models which are publicly available. By allowing for a custom OpenAI API compatible endpoint, users can take advantage of a broader set of hardware and model providers.

## Changes
- Added `base_url` parameter to `ChatGPTAgentConfig` to allow customization of the OpenAI API base URL.
- Updated `instantiate_openai_client` function to use the `base_url` parameter from the configuration.
- Modified `ChatGPTAgent` to utilize the updated `instantiate_openai_client` function.
- Modified the `get_tokenizer_info` function to allow for llama model usage with custom base URLs. This estimates the token usage and is not exact. Future feature expansion would be needed here to allow more models with certain token counting.
- Added tests to verify the new `base_url` functionality in `tests/streaming/agent/test_base_agent.py`.

This enhancement allows users to specify a custom OpenAI API base URL, providing greater flexibility in agent configuration.


## Usage

Example end to end example:

```.env
OPENAI_MODEL_NAME="llama3-70b-8192"
OPENAI_BASE_URL="https://api.groq.com/openai/v1"
OPENAI_API_KEY="<key here>"
ELEVENLABS_API_KEY="<key here>"
ELEVENLABS_VOICE_ID="<ID here>"
DEEPGRAM_API_KEY="<key here>"
```

```python
import asyncio
import signal
import os

from pydantic_settings import BaseSettings, SettingsConfigDict

from vocode.helpers import create_streaming_microphone_input_and_speaker_output
from vocode.logging import configure_pretty_logging
from vocode.streaming.agent.chat_gpt_agent import ChatGPTAgent
from vocode.streaming.models.agent import ChatGPTAgentConfig
from vocode.streaming.models.message import BaseMessage
from vocode.streaming.models.synthesizer import ElevenLabsSynthesizerConfig
from vocode.streaming.models.transcriber import (
    DeepgramTranscriberConfig,
    PunctuationEndpointingConfig,
)
from vocode.streaming.streaming_conversation import StreamingConversation
from vocode.streaming.synthesizer.eleven_labs_synthesizer import ElevenLabsSynthesizer
from vocode.streaming.transcriber.deepgram_transcriber import DeepgramTranscriber
from vocode.streaming.models.audio import AudioEncoding

configure_pretty_logging()

class Settings(BaseSettings):
    """
    Settings for the streaming conversation quickstart.
    These parameters can be configured with environment variables.
    """

    openai_api_key: str = os.environ.get('OPENAI_API_KEY', '')
    openai_model_name: str = os.environ.get('OPENAI_MODEL_NAME', '')
    openai_base_url: str = os.environ.get('OPENAI_BASE_URL', '')
    elevenlabs_api_key: str = os.environ.get('ELEVENLABS_API_KEY', '')
    elevenlabs_voice_id: str = os.environ.get('ELEVENLABS_VOICE_ID', '')
    deepgram_api_key: str = os.environ.get('DEEPGRAM_API_KEY', '')

    # This means a .env file can be used to overload these settings
    # ex: "OPENAI_API_KEY=my_key" will set openai_api_key over the default above
    model_config = SettingsConfigDict(
        env_file=".env",
        env_file_encoding="utf-8",
        extra="ignore"
    )


settings = Settings()


async def main():
    (
        microphone_input,
        speaker_output,
    ) = create_streaming_microphone_input_and_speaker_output(
        use_default_devices=False,
        speaker_sampling_rate=16000,
    )

    conversation = StreamingConversation(
        output_device=speaker_output,
        transcriber=DeepgramTranscriber(
            DeepgramTranscriberConfig.from_input_device(
                microphone_input,
                endpointing_config=PunctuationEndpointingConfig(),
                api_key=settings.deepgram_api_key,
            ),
        ),
        agent=ChatGPTAgent(
            ChatGPTAgentConfig(
                openai_api_key=settings.openai_api_key,
                model_name=settings.openai_model_name,
                base_url_override=settings.openai_base_url,
                initial_message=BaseMessage(text="What up"),
                prompt_preamble="""The AI is having a pleasant conversation about life""",
            )
        ),
        synthesizer=ElevenLabsSynthesizer(
            ElevenLabsSynthesizerConfig(
                api_key=settings.elevenlabs_api_key,
                voice_id=settings.elevenlabs_voice_id,
                sampling_rate=16000,
                audio_encoding=AudioEncoding.LINEAR16
            )
        ),
    )
    await conversation.start()
    print("Conversation started, press Ctrl+C to end")
    signal.signal(signal.SIGINT, lambda _0, _1: asyncio.create_task(conversation.terminate()))
    while conversation.is_active():
        chunk = await microphone_input.get_audio()
        conversation.receive_audio(chunk)


if __name__ == "__main__":
    asyncio.run(main())
```