### PR TITLE
removes groq from default factory

### DIFF
--- a/vocode/streaming/agent/default_factory.py
+++ b/vocode/streaming/agent/default_factory.py
@@ -3,7 +3,6 @@ from vocode.streaming.agent.anthropic_agent import AnthropicAgent
 from vocode.streaming.agent.base_agent import BaseAgent
 from vocode.streaming.agent.chat_gpt_agent import ChatGPTAgent
 from vocode.streaming.agent.echo_agent import EchoAgent
-from vocode.streaming.agent.groq_agent import GroqAgent
 from vocode.streaming.agent.restful_user_implemented_agent import RESTfulUserImplementedAgent
 from vocode.streaming.models.agent import (
     AgentConfig,
@@ -11,7 +10,6 @@ from vocode.streaming.models.agent import (
     ChatGPTAgentConfig,
     EchoAgentConfig,
     RESTfulUserImplementedAgentConfig,
-    GroqAgentConfig
 )
 
 
@@ -25,6 +23,4 @@ class DefaultAgentFactory(AbstractAgentFactory):
             return RESTfulUserImplementedAgent(agent_config=agent_config)
         elif isinstance(agent_config, AnthropicAgentConfig):
             return AnthropicAgent(agent_config=agent_config)
-        elif isinstance(agent_config, GroqAgentConfig):
-            return GroqAgent(agent_config=agent_config)
         raise Exception("Invalid agent config", agent_config.type)


### PR DESCRIPTION
groq isn't a core dependency, so let's leave it out of the default factory otherwise folks running the telephony server / using agent factory will run into an import error
