### PR TITLE
[DOW-113] deprecate output queue and manually attach workers to each other

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,5 +12,6 @@
   "rewrap.wrappingColumn": 100,
   "python.testing.unittestEnabled": false,
   "python.testing.pytestEnabled": true,
-  "isort.check": true
+  "isort.check": true,
+  "python.testing.pytestArgs": ["tests"]
 }

--- a/playground/streaming/agent/chat.py
+++ b/playground/streaming/agent/chat.py
@@ -158,6 +158,13 @@ async def run_agent(
                 break
 
     async def sender():
+        if agent.agent_config.initial_message is not None:
+            agent.agent_responses_consumer.consume_nonblocking(
+                InterruptibleAgentResponseEvent(
+                    payload=AgentResponseMessage(message=agent.agent_config.initial_message),
+                    agent_response_tracker=asyncio.Event(),
+                )
+            )
         while not ended:
             try:
                 message = await asyncio.get_event_loop().run_in_executor(
@@ -221,13 +228,6 @@ async def agent_main():
     )
     agent.attach_conversation_state_manager(DummyConversationManager())
     agent.attach_transcript(transcript)
-    if agent.agent_config.initial_message is not None:
-        agent.output_queue.put_nowait(
-            InterruptibleAgentResponseEvent(
-                payload=AgentResponseMessage(message=agent.agent_config.initial_message),
-                agent_response_tracker=asyncio.Event(),
-            )
-        )
     agent.start()
 
     try:

--- a/playground/streaming/transcriber/transcribe.py
+++ b/playground/streaming/transcriber/transcribe.py
@@ -11,7 +11,7 @@ from vocode.streaming.utils.worker import AsyncWorker
 class TranscriptionPrinter(AsyncWorker[Transcription]):
     async def _run_loop(self):
         while True:
-            transcription: Transcription = await self.input_queue.get()
+            transcription: Transcription = await self._input_queue.get()
             print(transcription)
 
 

--- a/tests/fakedata/conversation.py
+++ b/tests/fakedata/conversation.py
@@ -70,7 +70,7 @@ class DummyOutputDevice(AbstractOutputDevice):
         chunk_counter = 0
         while True:
             try:
-                item = await self.input_queue.get()
+                item = await self._input_queue.get()
             except asyncio.CancelledError:
                 return
             if self.wait_for_interrupt and chunk_counter == self.chunks_before_interrupt:
@@ -81,7 +81,7 @@ class DummyOutputDevice(AbstractOutputDevice):
     def flush(self):
         while True:
             try:
-                item = self.input_queue.get_nowait()
+                item = self._input_queue.get_nowait()
             except asyncio.QueueEmpty:
                 break
             self.process(item)

--- a/tests/fakedata/conversation.py
+++ b/tests/fakedata/conversation.py
@@ -1,5 +1,4 @@
 import asyncio
-import time
 from typing import Optional
 
 from pytest_mock import MockerFixture
@@ -52,6 +51,7 @@ class DummyOutputDevice(AbstractOutputDevice):
         self.wait_for_interrupt = wait_for_interrupt
         self.chunks_before_interrupt = chunks_before_interrupt
         self.interrupt_event = asyncio.Event()
+        self.dummy_playback_queue = asyncio.Queue()
 
     async def process(self, item):
         self.interruptible_event = item
@@ -61,6 +61,7 @@ class DummyOutputDevice(AbstractOutputDevice):
             audio_chunk.on_interrupt()
             audio_chunk.state = ChunkState.INTERRUPTED
         else:
+            self.dummy_playback_queue.put_nowait(audio_chunk)
             audio_chunk.on_play()
             audio_chunk.state = ChunkState.PLAYED
             self.interruptible_event.is_interruptible = False

--- a/tests/fixtures/synthesizer.py
+++ b/tests/fixtures/synthesizer.py
@@ -1,0 +1,50 @@
+import wave
+from io import BytesIO
+
+from vocode.streaming.models.message import BaseMessage
+from vocode.streaming.models.synthesizer import SynthesizerConfig
+from vocode.streaming.synthesizer.base_synthesizer import BaseSynthesizer, SynthesisResult
+
+
+def create_fake_audio(message: str, synthesizer_config: SynthesizerConfig):
+    file = BytesIO()
+    with wave.open(file, "wb") as wave_file:
+        wave_file.setnchannels(1)
+        wave_file.setsampwidth(2)
+        wave_file.setframerate(synthesizer_config.sampling_rate)
+        wave_file.writeframes(message.encode())
+    file.seek(0)
+    return file
+
+
+class TestSynthesizerConfig(SynthesizerConfig, type="synthesizer_test"):
+    __test__ = False
+
+
+class TestSynthesizer(BaseSynthesizer[TestSynthesizerConfig]):
+    """Accepts text and creates a SynthesisResult containing audio data which is the same as the text as bytes."""
+
+    __test__ = False
+
+    def __init__(self, synthesizer_config: SynthesizerConfig):
+        super().__init__(synthesizer_config)
+
+    async def create_speech_uncached(
+        self,
+        message: BaseMessage,
+        chunk_size: int,
+        is_first_text_chunk: bool = False,
+        is_sole_text_chunk: bool = False,
+    ) -> SynthesisResult:
+        return self.create_synthesis_result_from_wav(
+            synthesizer_config=self.synthesizer_config,
+            message=message,
+            chunk_size=chunk_size,
+            file=create_fake_audio(
+                message=message.text, synthesizer_config=self.synthesizer_config
+            ),
+        )
+
+    @classmethod
+    def get_voice_identifier(cls, synthesizer_config: TestSynthesizerConfig) -> str:
+        return "test_voice"

--- a/tests/fixtures/transcriber.py
+++ b/tests/fixtures/transcriber.py
@@ -16,7 +16,7 @@ class TestAsyncTranscriber(BaseAsyncTranscriber[TestTranscriberConfig]):
     async def _run_loop(self):
         while True:
             try:
-                audio_chunk = await self.input_queue.get()
+                audio_chunk = await self._input_queue.get()
                 self.produce_nonblocking(
                     Transcription(message=audio_chunk.decode("utf-8"), confidence=1, is_final=True)
                 )

--- a/tests/fixtures/transcriber.py
+++ b/tests/fixtures/transcriber.py
@@ -1,0 +1,24 @@
+import asyncio
+
+from vocode.streaming.models.transcriber import TranscriberConfig
+from vocode.streaming.transcriber.base_transcriber import BaseAsyncTranscriber, Transcription
+
+
+class TestTranscriberConfig(TranscriberConfig, type="transcriber_test"):
+    __test__ = False
+
+
+class TestAsyncTranscriber(BaseAsyncTranscriber[TestTranscriberConfig]):
+    """Accepts fake audio chunks and sends out transcriptions which are the same as the audio chunks."""
+
+    __test__ = False
+
+    async def _run_loop(self):
+        while True:
+            try:
+                audio_chunk = await self.input_queue.get()
+                self.produce_nonblocking(
+                    Transcription(message=audio_chunk.decode("utf-8"), confidence=1, is_final=True)
+                )
+            except asyncio.CancelledError:
+                return

--- a/tests/streaming/test_streaming_conversation.py
+++ b/tests/streaming/test_streaming_conversation.py
@@ -373,6 +373,9 @@ async def test_transcriptions_worker_interrupts_on_interim_transcripts(
         conversation_id="test",
     )
 
+    transcriptions_worker_consumer = QueueConsumer()
+    streaming_conversation.transcriptions_worker.consumer = transcriptions_worker_consumer
+    streaming_conversation.transcriptions_worker.start()
     streaming_conversation.transcriptions_worker.consume_nonblocking(
         Transcription(
             message="Sorry, could you stop",
@@ -380,10 +383,6 @@ async def test_transcriptions_worker_interrupts_on_interim_transcripts(
             is_final=False,
         ),
     )
-
-    transcriptions_worker_consumer = QueueConsumer()
-    streaming_conversation.transcriptions_worker.consumer = transcriptions_worker_consumer
-    streaming_conversation.transcriptions_worker.start()
 
     assert await _get_from_consumer_queue_if_exists(transcriptions_worker_consumer) is None
     assert streaming_conversation.broadcast_interrupt.called
@@ -419,6 +418,9 @@ async def test_transcriptions_worker_interrupts_immediately_before_bot_has_begun
 
     streaming_conversation.initial_message_tracker.set()
 
+    transcriptions_worker_consumer = QueueConsumer()
+    streaming_conversation.transcriptions_worker.consumer = transcriptions_worker_consumer
+    streaming_conversation.transcriptions_worker.start()
     streaming_conversation.transcriptions_worker.consume_nonblocking(
         Transcription(
             message="Sorry,",
@@ -426,9 +428,6 @@ async def test_transcriptions_worker_interrupts_immediately_before_bot_has_begun
             is_final=False,
         ),
     )
-    transcriptions_worker_consumer = QueueConsumer()
-    streaming_conversation.transcriptions_worker.consumer = transcriptions_worker_consumer
-    streaming_conversation.transcriptions_worker.start()
 
     assert await _get_from_consumer_queue_if_exists(transcriptions_worker_consumer) is None
     assert streaming_conversation.broadcast_interrupt.called

--- a/tests/streaming/test_streaming_conversation.py
+++ b/tests/streaming/test_streaming_conversation.py
@@ -235,7 +235,7 @@ async def test_transcriptions_worker_ignores_utterances_before_initial_message(
         mocker,
     )
 
-    streaming_conversation.transcriptions_worker.input_queue = asyncio.Queue()
+    streaming_conversation.transcriptions_worker._input_queue = asyncio.Queue()
     streaming_conversation.transcriptions_worker.output_queue = asyncio.Queue()
     streaming_conversation.transcriptions_worker.start()
     streaming_conversation.transcriptions_worker.consume_nonblocking(
@@ -301,7 +301,7 @@ async def test_transcriptions_worker_ignores_associated_ignored_utterance(
         mocker,
     )
 
-    streaming_conversation.transcriptions_worker.input_queue = asyncio.Queue()
+    streaming_conversation.transcriptions_worker._input_queue = asyncio.Queue()
     streaming_conversation.transcriptions_worker.output_queue = asyncio.Queue()
     streaming_conversation.transcriptions_worker.start()
     streaming_conversation.initial_message_tracker.set()
@@ -370,7 +370,7 @@ async def test_transcriptions_worker_interrupts_on_interim_transcripts(
         mocker,
     )
 
-    streaming_conversation.transcriptions_worker.input_queue = asyncio.Queue()
+    streaming_conversation.transcriptions_worker._input_queue = asyncio.Queue()
     streaming_conversation.transcriptions_worker.output_queue = asyncio.Queue()
     streaming_conversation.transcriptions_worker.start()
     streaming_conversation.initial_message_tracker.set()
@@ -423,7 +423,7 @@ async def test_transcriptions_worker_interrupts_immediately_before_bot_has_begun
         mocker,
     )
 
-    streaming_conversation.transcriptions_worker.input_queue = asyncio.Queue()
+    streaming_conversation.transcriptions_worker._input_queue = asyncio.Queue()
     streaming_conversation.transcriptions_worker.output_queue = asyncio.Queue()
     streaming_conversation.transcriptions_worker.start()
     streaming_conversation.initial_message_tracker.set()

--- a/vocode/streaming/action/worker.py
+++ b/vocode/streaming/action/worker.py
@@ -12,6 +12,7 @@ from vocode.streaming.models.actions import (
 )
 from vocode.streaming.utils.state_manager import AbstractConversationStateManager
 from vocode.streaming.utils.worker import (
+    AbstractWorker,
     InterruptibleEvent,
     InterruptibleEventFactory,
     InterruptibleWorker,
@@ -19,16 +20,14 @@ from vocode.streaming.utils.worker import (
 
 
 class ActionsWorker(InterruptibleWorker):
+    consumer: AbstractWorker[InterruptibleEvent[ActionResultAgentInput]]
+
     def __init__(
         self,
         action_factory: AbstractActionFactory,
-        input_queue: asyncio.Queue[InterruptibleEvent[ActionInput]],
-        output_queue: asyncio.Queue[InterruptibleEvent[AgentInput]],
         interruptible_event_factory: InterruptibleEventFactory = InterruptibleEventFactory(),
     ):
         super().__init__(
-            input_queue=input_queue,
-            output_queue=output_queue,
             interruptible_event_factory=interruptible_event_factory,
         )
         self.action_factory = action_factory
@@ -43,22 +42,24 @@ class ActionsWorker(InterruptibleWorker):
         action = self.action_factory.create_action(action_input.action_config)
         action.attach_conversation_state_manager(self.conversation_state_manager)
         action_output = await action.run(action_input)
-        self.produce_interruptible_event_nonblocking(
-            ActionResultAgentInput(
-                conversation_id=action_input.conversation_id,
-                action_input=action_input,
-                action_output=action_output,
-                vonage_uuid=(
-                    action_input.vonage_uuid
-                    if isinstance(action_input, VonagePhoneConversationActionInput)
-                    else None
+        self.consumer.consume_nonblocking(
+            self.interruptible_event_factory.create_interruptible_event(
+                ActionResultAgentInput(
+                    conversation_id=action_input.conversation_id,
+                    action_input=action_input,
+                    action_output=action_output,
+                    vonage_uuid=(
+                        action_input.vonage_uuid
+                        if isinstance(action_input, VonagePhoneConversationActionInput)
+                        else None
+                    ),
+                    twilio_sid=(
+                        action_input.twilio_sid
+                        if isinstance(action_input, TwilioPhoneConversationActionInput)
+                        else None
+                    ),
+                    is_quiet=action.quiet,
                 ),
-                twilio_sid=(
-                    action_input.twilio_sid
-                    if isinstance(action_input, TwilioPhoneConversationActionInput)
-                    else None
-                ),
-                is_quiet=action.quiet,
-            ),
-            is_interruptible=False,
+                is_interruptible=False,
+            )
         )

--- a/vocode/streaming/output_device/abstract_output_device.py
+++ b/vocode/streaming/output_device/abstract_output_device.py
@@ -16,7 +16,7 @@ class AbstractOutputDevice(AsyncWorker[InterruptibleEvent[AudioChunk]]):
     """
 
     def __init__(self, sampling_rate: int, audio_encoding: AudioEncoding):
-        super().__init__(input_queue=asyncio.Queue())
+        super().__init__()
         self.sampling_rate = sampling_rate
         self.audio_encoding = audio_encoding
 

--- a/vocode/streaming/output_device/blocking_speaker_output.py
+++ b/vocode/streaming/output_device/blocking_speaker_output.py
@@ -19,8 +19,7 @@ class _PlaybackWorker(ThreadAsyncWorker[bytes]):
     def __init__(self, *, device_info: dict, sampling_rate: int):
         self.sampling_rate = sampling_rate
         self.device_info = device_info
-        self.input_queue: asyncio.Queue[bytes] = asyncio.Queue()
-        super().__init__(self.input_queue)
+        super().__init__()
         self.stream = sd.OutputStream(
             channels=1,
             samplerate=self.sampling_rate,
@@ -28,7 +27,7 @@ class _PlaybackWorker(ThreadAsyncWorker[bytes]):
             device=int(self.device_info["index"]),
         )
         self._ended = False
-        self.input_queue.put_nowait(self.sampling_rate * b"\x00")
+        self.consume_nonblocking(self.sampling_rate * b"\x00")
         self.stream.start()
 
     def _run_loop(self):

--- a/vocode/streaming/output_device/livekit_output_device.py
+++ b/vocode/streaming/output_device/livekit_output_device.py
@@ -25,7 +25,7 @@ class LiveKitOutputDevice(AbstractOutputDevice):
     async def _run_loop(self):
         while True:
             try:
-                item = await self.input_queue.get()
+                item = await self._input_queue.get()
             except asyncio.CancelledError:
                 return
 

--- a/vocode/streaming/output_device/rate_limit_interruptions_output_device.py
+++ b/vocode/streaming/output_device/rate_limit_interruptions_output_device.py
@@ -27,7 +27,7 @@ class RateLimitInterruptionsOutputDevice(AbstractOutputDevice):
         while True:
             start_time = time.time()
             try:
-                item = await self.input_queue.get()
+                item = await self._input_queue.get()
             except asyncio.CancelledError:
                 return
 

--- a/vocode/streaming/synthesizer/miniaudio_worker.py
+++ b/vocode/streaming/synthesizer/miniaudio_worker.py
@@ -10,22 +10,38 @@ from loguru import logger
 from vocode.streaming.models.synthesizer import SynthesizerConfig
 from vocode.streaming.utils import convert_wav
 from vocode.streaming.utils.mp3_helper import decode_mp3
-from vocode.streaming.utils.worker import ThreadAsyncWorker
+from vocode.streaming.utils.worker import AbstractWorker, ThreadAsyncWorker
 
 
 class MiniaudioWorker(ThreadAsyncWorker[Union[bytes, None]]):
+    consumer: AbstractWorker[Tuple[bytes, bool]]
+
     def __init__(
         self,
         synthesizer_config: SynthesizerConfig,
         chunk_size: int,
-        input_queue: asyncio.Queue[Union[bytes, None]],
-        output_queue: asyncio.Queue[Tuple[bytes, bool]],
     ) -> None:
-        super().__init__(input_queue, output_queue)
-        self.output_queue = output_queue  # for typing
+        super().__init__()
         self.synthesizer_config = synthesizer_config
         self.chunk_size = chunk_size
         self._ended = False
+
+    async def run_thread_forwarding(self):
+        try:
+            await asyncio.gather(
+                self._forward_to_thread(),
+                self._forward_from_thread(),
+            )
+        except asyncio.CancelledError:
+            return
+
+    async def _forward_from_thread(self):
+        while True:
+            try:
+                chunk, done = await self.output_janus_queue.async_q.get()
+                self.consumer.consume_nonblocking((chunk, done))
+            except asyncio.CancelledError:
+                break
 
     def _run_loop(self):
         # tracks the mp3 so far

--- a/vocode/streaming/telephony/conversation/abstract_phone_conversation.py
+++ b/vocode/streaming/telephony/conversation/abstract_phone_conversation.py
@@ -66,12 +66,6 @@ class AbstractPhoneConversation(StreamingConversation[TelephonyOutputDeviceType]
             events_manager=events_manager,
             speed_coefficient=speed_coefficient,
         )
-        self.transcriptions_worker = self.TranscriptionsWorker(
-            input_queue=self.transcriber.output_queue,
-            output_queue=self.agent.get_input_queue(),
-            conversation=self,
-            interruptible_event_factory=self.interruptible_event_factory,
-        )
         self.config_manager = config_manager
 
     def attach_ws(self, ws: WebSocket):

--- a/vocode/streaming/transcriber/assembly_ai_transcriber.py
+++ b/vocode/streaming/transcriber/assembly_ai_transcriber.py
@@ -75,7 +75,7 @@ class AssemblyAITranscriber(BaseAsyncTranscriber[AssemblyAITranscriberConfig]):
         if (
             len(self.buffer) / (2 * self.transcriber_config.sampling_rate)
         ) >= self.transcriber_config.buffer_size_seconds:
-            self.input_queue.put_nowait(self.buffer)
+            self.consume_nonblocking(self.buffer)
             self.buffer = bytearray()
 
     def terminate(self):
@@ -133,7 +133,7 @@ class AssemblyAITranscriber(BaseAsyncTranscriber[AssemblyAITranscriberConfig]):
                     is_final = "message_type" in data and data["message_type"] == "FinalTranscript"
 
                     if "text" in data and data["text"]:
-                        self.output_queue.put_nowait(
+                        self.produce_nonblocking(
                             Transcription(
                                 message=data["text"],
                                 confidence=data["confidence"],

--- a/vocode/streaming/transcriber/assembly_ai_transcriber.py
+++ b/vocode/streaming/transcriber/assembly_ai_transcriber.py
@@ -106,7 +106,7 @@ class AssemblyAITranscriber(BaseAsyncTranscriber[AssemblyAITranscriberConfig]):
             async def sender(ws):  # sends audio to websocket
                 while not self._ended:
                     try:
-                        data = await asyncio.wait_for(self.input_queue.get(), 5)
+                        data = await asyncio.wait_for(self._input_queue.get(), 5)
                     except asyncio.exceptions.TimeoutError:
                         break
                     num_channels = 1

--- a/vocode/streaming/transcriber/azure_transcriber.py
+++ b/vocode/streaming/transcriber/azure_transcriber.py
@@ -79,12 +79,12 @@ class AzureTranscriber(BaseThreadAsyncTranscriber[AzureTranscriberConfig]):
             op=CustomSentrySpans.LATENCY_OF_CONVERSATION,
             start_timestamp=datetime.now(tz=timezone.utc),
         )
-        self.output_janus_queue.sync_q.put_nowait(
+        self.produce_nonblocking(
             Transcription(message=evt.result.text, confidence=1.0, is_final=True)
         )
 
     def recognized_sentence_stream(self, evt):
-        self.output_janus_queue.sync_q.put_nowait(
+        self.produce_nonblocking(
             Transcription(message=evt.result.text, confidence=1.0, is_final=False)
         )
 

--- a/vocode/streaming/transcriber/deepgram_transcriber.py
+++ b/vocode/streaming/transcriber/deepgram_transcriber.py
@@ -190,7 +190,7 @@ class DeepgramTranscriber(BaseAsyncTranscriber[DeepgramTranscriberConfig]):
             },
         )
         terminate_msg = json.dumps({"type": "CloseStream"}).encode("utf-8")
-        self.input_queue.put_nowait(terminate_msg)
+        self.consume_nonblocking(terminate_msg)  # todo (dow-107): typing
         self._ended = True
         super().terminate()
 
@@ -485,7 +485,7 @@ class DeepgramTranscriber(BaseAsyncTranscriber[DeepgramTranscriberConfig]):
                                 is_final_ts=is_final_ts,
                                 output_ts=output_ts,
                             )
-                            self.output_queue.put_nowait(
+                            self.produce_nonblocking(
                                 Transcription(
                                     message=buffer,
                                     confidence=buffer_avg_confidence,
@@ -513,7 +513,7 @@ class DeepgramTranscriber(BaseAsyncTranscriber[DeepgramTranscriberConfig]):
                                 else:
                                     interim_message = buffer
 
-                                self.output_queue.put_nowait(
+                                self.produce_nonblocking(
                                     Transcription(
                                         message=interim_message,
                                         confidence=deepgram_response.top_choice.confidence,

--- a/vocode/streaming/transcriber/deepgram_transcriber.py
+++ b/vocode/streaming/transcriber/deepgram_transcriber.py
@@ -404,7 +404,7 @@ class DeepgramTranscriber(BaseAsyncTranscriber[DeepgramTranscriberConfig]):
 
                     while not self._ended:
                         try:
-                            data = await asyncio.wait_for(self.input_queue.get(), 5)
+                            data = await asyncio.wait_for(self._input_queue.get(), 5)
                         except asyncio.exceptions.TimeoutError:
                             break
 

--- a/vocode/streaming/transcriber/gladia_transcriber.py
+++ b/vocode/streaming/transcriber/gladia_transcriber.py
@@ -53,7 +53,7 @@ class GladiaTranscriber(BaseAsyncTranscriber[GladiaTranscriberConfig]):
         if (
             len(self.buffer) / (2 * self.transcriber_config.sampling_rate)
         ) >= self.transcriber_config.buffer_size_seconds:
-            self.input_queue.put_nowait(self.buffer)
+            self.consume_nonblocking(self.buffer)
             self.buffer = bytearray()
 
     def terminate(self):
@@ -104,7 +104,7 @@ class GladiaTranscriber(BaseAsyncTranscriber[GladiaTranscriberConfig]):
                         is_final = data["type"] == "final"
 
                         if "transcription" in data and data["transcription"]:
-                            self.output_queue.put_nowait(
+                            self.produce_nonblocking(
                                 Transcription(
                                     message=data["transcription"],
                                     confidence=data["confidence"],

--- a/vocode/streaming/transcriber/gladia_transcriber.py
+++ b/vocode/streaming/transcriber/gladia_transcriber.py
@@ -75,7 +75,7 @@ class GladiaTranscriber(BaseAsyncTranscriber[GladiaTranscriberConfig]):
             async def sender(ws):
                 while not self._ended:
                     try:
-                        data = await asyncio.wait_for(self.input_queue.get(), 5)
+                        data = await asyncio.wait_for(self._input_queue.get(), 5)
                     except asyncio.exceptions.TimeoutError:
                         break
 

--- a/vocode/streaming/transcriber/google_transcriber.py
+++ b/vocode/streaming/transcriber/google_transcriber.py
@@ -80,7 +80,7 @@ class GoogleTranscriber(BaseThreadAsyncTranscriber[GoogleTranscriberConfig]):
         message = top_choice.transcript
         confidence = top_choice.confidence
 
-        self.output_janus_queue.sync_q.put_nowait(
+        self.produce_nonblocking(
             Transcription(message=message, confidence=confidence, is_final=result.is_final)
         )
 

--- a/vocode/streaming/transcriber/rev_ai_transcriber.py
+++ b/vocode/streaming/transcriber/rev_ai_transcriber.py
@@ -118,12 +118,12 @@ class RevAITranscriber(BaseAsyncTranscriber[RevAITranscriberConfig]):
 
                     confidence = 1.0
                     if is_done:
-                        self.output_queue.put_nowait(
+                        self.produce_nonblocking(
                             Transcription(message=buffer, confidence=confidence, is_final=True)
                         )
                         buffer = ""
                     else:
-                        self.output_queue.put_nowait(
+                        self.produce_nonblocking(
                             Transcription(
                                 message=buffer,
                                 confidence=confidence,
@@ -137,5 +137,5 @@ class RevAITranscriber(BaseAsyncTranscriber[RevAITranscriberConfig]):
 
     def terminate(self):
         terminate_msg = json.dumps({"type": "CloseStream"})
-        self.input_queue.put_nowait(terminate_msg)
+        self.consume_nonblocking(terminate_msg)
         self.closed = True

--- a/vocode/streaming/transcriber/rev_ai_transcriber.py
+++ b/vocode/streaming/transcriber/rev_ai_transcriber.py
@@ -74,7 +74,7 @@ class RevAITranscriber(BaseAsyncTranscriber[RevAITranscriberConfig]):
             async def sender(ws: WebSocketClientProtocol):
                 while not self.closed:
                     try:
-                        data = await asyncio.wait_for(self.input_queue.get(), 5)
+                        data = await asyncio.wait_for(self._input_queue.get(), 5)
                     except asyncio.exceptions.TimeoutError:
                         break
                     await ws.send(data)

--- a/vocode/streaming/transcriber/whisper_cpp_transcriber.py
+++ b/vocode/streaming/transcriber/whisper_cpp_transcriber.py
@@ -72,7 +72,7 @@ class WhisperCPPTranscriber(BaseThreadAsyncTranscriber[WhisperCPPTranscriberConf
                 message_buffer += message
                 is_final = any(message_buffer.endswith(ending) for ending in SENTENCE_ENDINGS)
                 in_memory_wav, audio_buffer = self.create_new_buffer()
-                self.output_queue.put_nowait(
+                self.produce_nonblocking(
                     Transcription(message=message_buffer, confidence=confidence, is_final=is_final)
                 )
                 if is_final:

--- a/vocode/streaming/utils/worker.py
+++ b/vocode/streaming/utils/worker.py
@@ -29,7 +29,7 @@ class AbstractWorker(Generic[WorkerInputType], ABC):
 class QueueConsumer(AbstractWorker[WorkerInputType]):
     def __init__(
         self,
-        input_queue: asyncio.Queue[WorkerInputType] = None,
+        input_queue: Optional[asyncio.Queue[WorkerInputType]] = None,
     ) -> None:
         self.input_queue: asyncio.Queue[WorkerInputType] = input_queue or asyncio.Queue()
 

--- a/vocode/streaming/utils/worker.py
+++ b/vocode/streaming/utils/worker.py
@@ -29,8 +29,9 @@ class AbstractWorker(Generic[WorkerInputType], ABC):
 class QueueConsumer(AbstractWorker[WorkerInputType]):
     def __init__(
         self,
+        input_queue: asyncio.Queue[WorkerInputType] = None,
     ) -> None:
-        self.input_queue: asyncio.Queue[WorkerInputType] = asyncio.Queue()
+        self.input_queue: asyncio.Queue[WorkerInputType] = input_queue or asyncio.Queue()
 
     def consume_nonblocking(self, item: WorkerInputType):
         self.input_queue.put_nowait(item)

--- a/vocode/streaming/utils/worker.py
+++ b/vocode/streaming/utils/worker.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import threading
-from typing import Any, Generic, Optional, TypeVar
+from abc import ABC, abstractmethod
+from typing import Any, Dict, Generic, List, Optional, TypeVar
 
 import janus
 from loguru import logger
@@ -12,15 +13,38 @@ from vocode.streaming.utils.create_task import asyncio_create_task_with_done_err
 WorkerInputType = TypeVar("WorkerInputType")
 
 
-class AsyncWorker(Generic[WorkerInputType]):
+class AbstractWorker(Generic[WorkerInputType], ABC):
+    @abstractmethod
+    def start(self):
+        raise NotImplementedError
+
+    @abstractmethod
+    def consume_nonblocking(self, item: WorkerInputType):
+        raise NotImplementedError
+
+    def terminate(self):
+        pass
+
+
+class QueueConsumer(AbstractWorker[WorkerInputType]):
     def __init__(
         self,
-        input_queue: asyncio.Queue[WorkerInputType],
-        output_queue: asyncio.Queue = asyncio.Queue(),
+    ) -> None:
+        self.input_queue: asyncio.Queue[WorkerInputType] = asyncio.Queue()
+
+    def consume_nonblocking(self, item: WorkerInputType):
+        self.input_queue.put_nowait(item)
+
+    def start(self):
+        pass
+
+
+class AsyncWorker(AbstractWorker[WorkerInputType]):
+    def __init__(
+        self,
     ) -> None:
         self.worker_task: Optional[asyncio.Task] = None
-        self.input_queue = input_queue
-        self.output_queue = output_queue
+        self.input_queue: asyncio.Queue[WorkerInputType] = asyncio.Queue()
 
     def start(self) -> asyncio.Task:
         self.worker_task = asyncio_create_task_with_done_error_log(
@@ -32,9 +56,6 @@ class AsyncWorker(Generic[WorkerInputType]):
 
     def consume_nonblocking(self, item: WorkerInputType):
         self.input_queue.put_nowait(item)
-
-    def produce_nonblocking(self, item):
-        self.output_queue.put_nowait(item)
 
     async def _run_loop(self):
         raise NotImplementedError
@@ -49,10 +70,8 @@ class AsyncWorker(Generic[WorkerInputType]):
 class ThreadAsyncWorker(AsyncWorker[WorkerInputType]):
     def __init__(
         self,
-        input_queue: asyncio.Queue[WorkerInputType],
-        output_queue: asyncio.Queue = asyncio.Queue(),
     ) -> None:
-        super().__init__(input_queue, output_queue)
+        super().__init__()
         self.worker_thread: Optional[threading.Thread] = None
         self.input_janus_queue: janus.Queue[WorkerInputType] = janus.Queue()
         self.output_janus_queue: janus.Queue = janus.Queue()
@@ -69,10 +88,7 @@ class ThreadAsyncWorker(AsyncWorker[WorkerInputType]):
 
     async def run_thread_forwarding(self):
         try:
-            await asyncio.gather(
-                self._forward_to_thread(),
-                self._forward_from_thead(),
-            )
+            await self._forward_to_thread()
         except asyncio.CancelledError:
             return
 
@@ -81,16 +97,8 @@ class ThreadAsyncWorker(AsyncWorker[WorkerInputType]):
             item = await self.input_queue.get()
             self.input_janus_queue.async_q.put_nowait(item)
 
-    async def _forward_from_thead(self):
-        while True:
-            item = await self.output_janus_queue.async_q.get()
-            self.output_queue.put_nowait(item)
-
     def _run_loop(self):
         raise NotImplementedError
-
-    def terminate(self):
-        return super().terminate()
 
 
 class AsyncQueueWorker(AsyncWorker[WorkerInputType]):
@@ -180,38 +188,14 @@ InterruptibleEventType = TypeVar("InterruptibleEventType", bound=InterruptibleEv
 class InterruptibleWorker(AsyncWorker[InterruptibleEventType]):
     def __init__(
         self,
-        input_queue: asyncio.Queue[InterruptibleEventType],
-        output_queue: asyncio.Queue = asyncio.Queue(),
         interruptible_event_factory: InterruptibleEventFactory = InterruptibleEventFactory(),
         max_concurrency=2,
     ) -> None:
-        super().__init__(input_queue, output_queue)
-        self.input_queue = input_queue
+        super().__init__()
         self.max_concurrency = max_concurrency
         self.interruptible_event_factory = interruptible_event_factory
         self.current_task = None
         self.interruptible_event = None
-
-    def produce_interruptible_event_nonblocking(self, item: Any, is_interruptible: bool = True):
-        interruptible_event = self.interruptible_event_factory.create_interruptible_event(
-            item, is_interruptible=is_interruptible
-        )
-        return super().produce_nonblocking(interruptible_event)
-
-    def produce_interruptible_agent_response_event_nonblocking(
-        self,
-        item: Any,
-        is_interruptible: bool = True,
-        agent_response_tracker: Optional[asyncio.Event] = None,
-    ):
-        interruptible_utterance_event = (
-            self.interruptible_event_factory.create_interruptible_agent_response_event(
-                item,
-                is_interruptible=is_interruptible,
-                agent_response_tracker=agent_response_tracker or asyncio.Event(),
-            )
-        )
-        return super().produce_nonblocking(interruptible_utterance_event)
 
     async def _run_loop(self):
         # TODO Implement concurrency with max_nb_of_thread

--- a/vocode/streaming/utils/worker.py
+++ b/vocode/streaming/utils/worker.py
@@ -14,6 +14,11 @@ WorkerInputType = TypeVar("WorkerInputType")
 
 
 class AbstractWorker(Generic[WorkerInputType], ABC):
+    """
+    A generic processor - knows only how to consume typed items.
+    In order for a worker to process items, clients must invoke start() and tear down with terminate()
+    """
+
     @abstractmethod
     def start(self):
         raise NotImplementedError


### PR DESCRIPTION
overall idea here - pushes the notion of queues under the abstraction barrier of workers. Workers _do not_ need to know about the inner workings of how other workers process their events. In order to wire up workers, manually connect them to each other using instance variables and only use `consume_nonblocking` to communicate - this also improves the typing of events coming out of workers.

Mechanically:
- creates `AbstractWorker` which just knows how to consume inputs, but places no restrictions on how it creates `asyncio.Queue`s to do the processing
- changes `AsyncWorker` to only create an `input_queue`, and not have it be overrideable
- change the constructor of `StreamingConversation` so that the workers are connected to each other as described above

Also adds a nice test that asserts that a message can make it through the whole pipeline (`test_streaming_conversation_pipeline`)