### PR TITLE
Support passthrough of transport options

### DIFF
--- a/tests/streaming/action/test_external_actions_requester.py
+++ b/tests/streaming/action/test_external_actions_requester.py
@@ -5,6 +5,7 @@ import json
 import os
 from typing import Any, Callable, Dict
 
+import httpx
 import pytest
 from httpx import Request, Response
 from pytest_httpx import HTTPXMock
@@ -65,7 +66,7 @@ async def test_send_request_responses(
         JSON_SCHEMA,
         base64.b64encode(os.urandom(32)).decode(),
         additional_payload_values={"call_id": "call_id"},
-        transport_options={"retries": 3, "verify": True},
+        transport=httpx.AsyncHTTPTransport(retries=3, verify=True),
     )
 
     assert response.success is expected_success

--- a/tests/streaming/action/test_external_actions_requester.py
+++ b/tests/streaming/action/test_external_actions_requester.py
@@ -65,6 +65,7 @@ async def test_send_request_responses(
         JSON_SCHEMA,
         base64.b64encode(os.urandom(32)).decode(),
         additional_payload_values={"call_id": "call_id"},
+        transport_options={"retries": 3, "verify": True},
     )
 
     assert response.success is expected_success

--- a/vocode/streaming/action/external_actions_requester.py
+++ b/vocode/streaming/action/external_actions_requester.py
@@ -63,7 +63,7 @@ class ExternalActionsRequester:
             "x-vocode-signature": self._encode_payload(encoded_payload, signature_secret),
         }
 
-        transport = httpx.AsyncHTTPTransport(retries=2)
+        transport = httpx.AsyncHTTPTransport(retries=2, verify=False)
         async with httpx.AsyncClient(
             headers=headers,
             transport=transport,

--- a/vocode/streaming/action/external_actions_requester.py
+++ b/vocode/streaming/action/external_actions_requester.py
@@ -52,7 +52,7 @@ class ExternalActionsRequester:
         payload: Dict[str, Any],
         signature_secret: str,
         additional_payload_values: Dict[str, Any] = {},
-        transport_options: Dict[str, Any] = {"retries": 2},
+        transport: httpx.AsyncHTTPTransport = httpx.AsyncHTTPTransport(retries=2),
     ) -> ExternalActionResponse:
         encoded_payload = json.dumps({"payload": payload} | additional_payload_values).encode(
             "utf-8"
@@ -64,7 +64,6 @@ class ExternalActionsRequester:
             "x-vocode-signature": self._encode_payload(encoded_payload, signature_secret),
         }
 
-        transport = httpx.AsyncHTTPTransport(**transport_options)
         async with httpx.AsyncClient(
             headers=headers,
             transport=transport,

--- a/vocode/streaming/action/external_actions_requester.py
+++ b/vocode/streaming/action/external_actions_requester.py
@@ -52,6 +52,7 @@ class ExternalActionsRequester:
         payload: Dict[str, Any],
         signature_secret: str,
         additional_payload_values: Dict[str, Any] = {},
+        transport_options: Dict[str, Any] = {"retries": 2},
     ) -> ExternalActionResponse:
         encoded_payload = json.dumps({"payload": payload} | additional_payload_values).encode(
             "utf-8"
@@ -63,7 +64,7 @@ class ExternalActionsRequester:
             "x-vocode-signature": self._encode_payload(encoded_payload, signature_secret),
         }
 
-        transport = httpx.AsyncHTTPTransport(retries=2, verify=False)
+        transport = httpx.AsyncHTTPTransport(**transport_options)
         async with httpx.AsyncClient(
             headers=headers,
             transport=transport,


### PR DESCRIPTION
## Summary
External actions simply post to a given configured URL. Whether that URL has valid SSL should be irrelevant to us since it's configured by the user. This change makes it so consumers of the library can specify their own transport options and decide whether or not to verify the URL