### PR TITLE
uses .value instead of passing enum for sampling rate

### DIFF
--- a/vocode/streaming/models/synthesizer.py
+++ b/vocode/streaming/models/synthesizer.py
@@ -220,7 +220,7 @@ class BarkSynthesizerConfig(SynthesizerConfig, type=SynthesizerType.BARK.value):
 
 DEFAULT_POLLY_LANGUAGE_CODE = "en-US"
 DEFAULT_POLLY_VOICE_ID = "Matthew"
-DEFAULT_POLLY_SAMPLING_RATE = SamplingRate.RATE_16000
+DEFAULT_POLLY_SAMPLING_RATE = SamplingRate.RATE_16000.value
 
 
 class PollySynthesizerConfig(SynthesizerConfig, type=SynthesizerType.POLLY.value):  # type: ignore

--- a/vocode/streaming/telephony/constants.py
+++ b/vocode/streaming/telephony/constants.py
@@ -1,12 +1,12 @@
 from vocode.streaming.models.audio import AudioEncoding, SamplingRate
 
 # TODO(EPD-186): namespace as Twilio
-DEFAULT_SAMPLING_RATE = SamplingRate.RATE_8000
+DEFAULT_SAMPLING_RATE: int = SamplingRate.RATE_8000.value
 DEFAULT_AUDIO_ENCODING = AudioEncoding.MULAW
 DEFAULT_CHUNK_SIZE = 20 * 160
 MULAW_SILENCE_BYTE = b"\xff"
 
-VONAGE_SAMPLING_RATE = SamplingRate.RATE_16000
+VONAGE_SAMPLING_RATE: int = SamplingRate.RATE_16000.value
 VONAGE_AUDIO_ENCODING = AudioEncoding.LINEAR16
 VONAGE_CHUNK_SIZE = 640  # 20ms at 16kHz with 16bit samples
 VONAGE_CONTENT_TYPE = "audio/l16;rate=16000"


### PR DESCRIPTION
discovered this when trying to run calls with the `InMemoryConfigManager` - we should use this enum for comparison, but not use it as an enum to pass around values

this is hidden for phone calls that use Redis, since we serialize the Pydantic object which converts RATE_8000 --> 8000