### PR TITLE
phrase trigger matcher returns agent config instead of type

### DIFF
--- a/vocode/streaming/agent/base_agent.py
+++ b/vocode/streaming/agent/base_agent.py
@@ -340,15 +340,13 @@ class RespondAgent(BaseAgent[AgentConfigType]):
                 agent_response_tracker=end_of_turn_agent_response_tracker,
             )
 
-        phrase_trigger_match = (
+        phrase_trigger_match_action_config = (
             matches_phrase_trigger(responses_buffer, self.agent_config.actions)
             if self.agent_config.actions
             else None
         )
-        if phrase_trigger_match:
-            action_config = self._get_action_config(phrase_trigger_match)
-            assert action_config is not None
-            action = self.action_factory.create_action(action_config)
+        if phrase_trigger_match_action_config:
+            action = self.action_factory.create_action(phrase_trigger_match_action_config)
             action_input = self.create_action_input(
                 action,
                 agent_input,

--- a/vocode/streaming/agent/phrase_trigger.py
+++ b/vocode/streaming/agent/phrase_trigger.py
@@ -7,7 +7,7 @@ from vocode.streaming.models.actions import ActionConfig, PhraseBasedActionTrigg
 def matches_phrase_trigger(
     message: str,
     action_configs: List[ActionConfig],
-) -> Optional[str]:
+) -> Optional[ActionConfig]:
     cleaned = re.sub(r"[^\w\s]", "", message.lower())
     for action_config in action_configs:
         if not isinstance(action_config.action_trigger, PhraseBasedActionTrigger):
@@ -17,5 +17,5 @@ def matches_phrase_trigger(
             lowered = phrase_trigger.phrase.lower()
             for condition in phrase_trigger.conditions:
                 if condition == "phrase_condition_type_contains" and lowered in cleaned:
-                    return action_config.type
+                    return action_config
     return None


### PR DESCRIPTION
Context:
In the case where an agent has multiple actions of the same type but different phrase triggers, the wrong action may be activated. So if you have two actions that transfer to different numbers, and one is activated by "a" and the other is activated by "b", the agent may say "b" but the action for "a" is activated. 

Root cause:
The phrase trigger check returns the action type, which is then matched back to an action config (this means any of the actions with the same type can be activated, causing the bug).

Fix:
Instead of returning the action type from the phrase trigger check, return the action config itself.

Tested locally on a call with multiple transfer actions, confirming the fix works.