### PR TITLE
Remove exception logs for InterruptibleWorker and AsyncQueueWorker

### DIFF
--- a/vocode/streaming/utils/worker.py
+++ b/vocode/streaming/utils/worker.py
@@ -115,8 +115,6 @@ class AsyncQueueWorker(AsyncWorker[WorkerInputType]):
                 await self.process(item)
             except asyncio.CancelledError:
                 return
-            except Exception:
-                logger.exception("AsyncQueueWorker", exc_info=True)
 
     async def process(self, item):
         """
@@ -222,8 +220,6 @@ class InterruptibleWorker(AsyncWorker[InterruptibleEventType]):
                 await self.current_task
             except asyncio.CancelledError:
                 return
-            except Exception:
-                logger.exception("InterruptibleWorker", exc_info=True)
             self.interruptible_event.is_interruptible = False
             self.current_task = None
 


### PR DESCRIPTION
Both of these workers have a catch-all statement that raises a log on an exception instead of fully raising the error itself. This:

1. Prevents the error from breaking the flow
2. Causes sentry to catch the log separately from asyncio and raise the error twice