### PR TITLE
convert twilio 400 to a warning log instead of an error log

### DIFF
--- a/vocode/streaming/telephony/client/twilio_client.py
+++ b/vocode/streaming/telephony/client/twilio_client.py
@@ -63,7 +63,7 @@ class TwilioClient(AbstractTelephonyClient):
         ) as response:
             if not response.ok:
                 if response.status == 400:
-                    logger.error(
+                    logger.warning(
                         f"Failed to create call: {response.status} {response.reason} {await response.json()}"
                     )
                     raise TwilioBadRequestException(


### PR DESCRIPTION
would manifest in sentry as an unhandled error, e.g. when this could be a user error