### PR TITLE
Fix typo in Hosted Walkthrough

### DIFF
--- a/docs/walkthrough_intro.mdx
+++ b/docs/walkthrough_intro.mdx
@@ -6,7 +6,7 @@ description: "Setting up a simple receptionist agent"
 Welcome to the Vocode API! We've got a lot of powerful features that we're going to illustrate
 by setting up a receptionist agent that can take calls and book calendar appointments.
 
-We'll cover how to do it step-by-step entirely via API or you could also follow along usig our
+We'll cover how to do it step-by-step entirely via API or you could also follow along using our
 [Dashboard]("https://dashboard.vocode.dev).
 
 In particular, we'll go through the following steps:


### PR DESCRIPTION
# What
Fix spelling in [walkthrough](https://docs.vocode.dev/walkthrough_intro)