### PR TITLE
Poll time for idle changed to half of idle time threshold

### DIFF
--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -773,7 +773,7 @@ class StreamingConversation(AudioPipeline[OutputDeviceType]):
                 )
                 check_human_present_count += 1
             # wait till the idle time would have passed the threshold if no action occurs
-            await asyncio.sleep(ALLOWED_IDLE_TIME)
+            await asyncio.sleep(self.idle_time_threshold / 2)
 
     async def send_single_message(
         self,


### PR DESCRIPTION
## Summary
Previously, we were polling at a fixed time period to check for idleness. This change updates the polling interval to scale according to the idle time threshold (set to half of the idle time threshold)