### PR TITLE
Reset check_human_present_count when human is actually present

### DIFF
--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -275,6 +275,7 @@ class StreamingConversation(AudioPipeline[OutputDeviceType]):
                 if self.conversation.current_transcription_is_interrupt:
                     logger.debug("sent interrupt")
                 logger.debug("Human started speaking")
+                self.conversation.is_human_still_there = True
 
             transcription.is_interrupt = self.conversation.current_transcription_is_interrupt
             self.conversation.is_human_speaking = not transcription.is_final
@@ -667,6 +668,7 @@ class StreamingConversation(AudioPipeline[OutputDeviceType]):
 
         self.check_for_idle_task: Optional[asyncio.Task] = None
         self.check_for_idle_paused = False
+        self.is_human_still_there = True
 
         self.current_transcription_is_interrupt: bool = False
 
@@ -762,12 +764,16 @@ class StreamingConversation(AudioPipeline[OutputDeviceType]):
         check_human_present_count = 0
         check_human_present_threshold = self.agent.get_agent_config().num_check_human_present_times
         while self.is_active():
+            if check_human_present_count > 0 and self.is_human_still_there == True:
+                # Reset the counter if the human is still there
+                check_human_present_count = 0
             if (
                 not self.check_for_idle_paused
             ) and time.time() - self.last_action_timestamp > self.idle_time_threshold:
                 if check_human_present_count >= check_human_present_threshold:
                     # Stop the phone call after some retries to prevent infinitely long call where human is just silent.
                     await self.action_on_idle()
+                self.is_human_still_there = False
                 await self.send_single_message(
                     message=BaseMessage(text=random.choice(CHECK_HUMAN_PRESENT_MESSAGE_CHOICES)),
                 )


### PR DESCRIPTION
## Summary
Previously we kept a monotonically increasing global counter per call of how many times we've asked if the human was there  when idle.

This change will reset that counter if the human actually did respond indicating the human is still there.