### PR TITLE
Update google_synthesizer.py

### DIFF
--- a/vocode/streaming/synthesizer/google_synthesizer.py
+++ b/vocode/streaming/synthesizer/google_synthesizer.py
@@ -51,7 +51,7 @@ class GoogleSynthesizer(BaseSynthesizer[GoogleSynthesizerConfig]):
                 input=synthesis_input,
                 voice=self.voice,
                 audio_config=self.audio_config,
-                enable_time_pointing=[tts.SynthesizeSpeechRequest.TimepointType.SSML_MARK],
+                
             )
         )
 
@@ -68,7 +68,7 @@ class GoogleSynthesizer(BaseSynthesizer[GoogleSynthesizerConfig]):
                 self.thread_pool_executor, self.synthesize, message.text
             )
         )
-        output_sample_rate = response.audio_config.sample_rate_hertz
+        output_sample_rate = self.audio_config.sample_rate_hertz
 
         output_bytes_io = io.BytesIO()
         in_memory_wav = wave.open(output_bytes_io, "wb")


### PR DESCRIPTION
in line 54, it seems the latest version of google.cloud speech didn't have the attribute  AttributeError: type object 'SynthesizeSpeechRequest' has no attribute 'TimepointType'


in line 72, the synthesize speech response didn't have field called audio_config Unknown field for SynthesizeSpeechResponse: audio_config