### PR TITLE
[Cartesia] Upgrading the message cutoff for Cartesia Synthesizer to use timestamps

### DIFF
--- a/vocode/streaming/synthesizer/cartesia_synthesizer.py
+++ b/vocode/streaming/synthesizer/cartesia_synthesizer.py
@@ -1,8 +1,8 @@
 import asyncio
 import hashlib
+from typing import List, Tuple
 
 from loguru import logger
-from typing import List, Tuple
 
 from vocode import getenv
 from vocode.streaming.models.audio import AudioEncoding, SamplingRate

--- a/vocode/streaming/synthesizer/cartesia_synthesizer.py
+++ b/vocode/streaming/synthesizer/cartesia_synthesizer.py
@@ -90,6 +90,8 @@ class CartesiaSynthesizer(BaseSynthesizer[CartesiaSynthesizerConfig]):
         self.client = self.cartesia_tts(api_key=self.api_key)
         self.ws = None
         self.ctx = None
+        self.ctx_message = BaseMessage(text="")
+        self.ctx_timestamps = []
         self.no_more_inputs_task = None
         self.no_more_inputs_lock = asyncio.Lock()
 
@@ -99,10 +101,14 @@ class CartesiaSynthesizer(BaseSynthesizer[CartesiaSynthesizerConfig]):
 
     async def initialize_ctx(self, is_first_text_chunk: bool):
         if self.ctx is None or self.ctx.is_closed():
+            self.ctx_message = BaseMessage(text="")
+            self.ctx_timestamps = []
             if self.ws:
                 self.ctx = self.ws.context()
         else:
             if is_first_text_chunk:
+                self.ctx_message = BaseMessage(text="")
+                self.ctx_timestamps = []
                 if self.no_more_inputs_task:
                     self.no_more_inputs_task.cancel()
                 await self.ctx.no_more_inputs()
@@ -144,6 +150,7 @@ class CartesiaSynthesizer(BaseSynthesizer[CartesiaSynthesizerConfig]):
                 voice_id=self.voice_id,
                 continue_=not is_sole_text_chunk,
                 output_format=self.output_format,
+                add_timestamps=True,
                 _experimental_voice_controls=self._experimental_voice_controls,
             )
             if not is_sole_text_chunk:
@@ -159,12 +166,20 @@ class CartesiaSynthesizer(BaseSynthesizer[CartesiaSynthesizerConfig]):
             try:
                 async for event in context.receive():
                     audio = event.get("audio")
-                    buffer.extend(audio)
-                    while len(buffer) >= chunk_size:
-                        yield SynthesisResult.ChunkResult(
-                            chunk=buffer[:chunk_size], is_last_chunk=False
-                        )
-                        buffer = buffer[chunk_size:]
+                    word_timestamps = event.get("word_timestamps")
+                    if word_timestamps:
+                        words = word_timestamps['words']
+                        start_times = word_timestamps['start']
+                        end_times = word_timestamps['end']
+                        for word, start, end in zip(words, start_times, end_times):
+                            self.ctx_timestamps.append((word, start, end))
+                    if audio:
+                        buffer.extend(audio)
+                        while len(buffer) >= chunk_size:
+                            yield SynthesisResult.ChunkResult(
+                                chunk=buffer[:chunk_size], is_last_chunk=False
+                            )
+                            buffer = buffer[chunk_size:]
             except Exception as e:
                 logger.info(
                     f"Caught error while receiving audio chunks from CartesiaSynthesizer: {e}"
@@ -180,11 +195,27 @@ class CartesiaSynthesizer(BaseSynthesizer[CartesiaSynthesizerConfig]):
                         buffer.extend(b"\x00\x00" * padding_size)  # 0 is silence in s16le
                 yield SynthesisResult.ChunkResult(chunk=buffer, is_last_chunk=True)
 
+        self.ctx_message.text += transcript
+
+        def get_message_cutoff_ctx(message, seconds, words_per_minute=150):
+            if seconds:
+                closest_index = 0
+                if len(self.ctx_timestamps) > 0:
+                    for index, word_timestamp in enumerate(self.ctx_timestamps):
+                        _word, start, end = word_timestamp
+                        closest_index = index
+                        if end >= seconds:
+                            break
+                if closest_index:
+                    # Check if they're less than 2 seconds apart, fall back to words per minute otherwise
+                    if self.ctx_timestamps[closest_index][2] - seconds < 2:
+                        return " ".join([word for word, *_ in self.ctx_timestamps[:closest_index + 1]])
+            return self.get_message_cutoff_from_voice_speed(message, seconds, words_per_minute)
+
+
         return SynthesisResult(
             chunk_generator=chunk_generator(self.ctx),
-            get_message_up_to=lambda seconds: self.get_message_cutoff_from_voice_speed(
-                message, seconds
-            ),
+            get_message_up_to=lambda seconds: get_message_cutoff_ctx(self.ctx_message, seconds),
         )
 
     @classmethod

--- a/vocode/streaming/synthesizer/cartesia_synthesizer.py
+++ b/vocode/streaming/synthesizer/cartesia_synthesizer.py
@@ -168,9 +168,9 @@ class CartesiaSynthesizer(BaseSynthesizer[CartesiaSynthesizerConfig]):
                     audio = event.get("audio")
                     word_timestamps = event.get("word_timestamps")
                     if word_timestamps:
-                        words = word_timestamps['words']
-                        start_times = word_timestamps['start']
-                        end_times = word_timestamps['end']
+                        words = word_timestamps["words"]
+                        start_times = word_timestamps["start"]
+                        end_times = word_timestamps["end"]
                         for word, start, end in zip(words, start_times, end_times):
                             self.ctx_timestamps.append((word, start, end))
                     if audio:
@@ -209,9 +209,10 @@ class CartesiaSynthesizer(BaseSynthesizer[CartesiaSynthesizerConfig]):
                 if closest_index:
                     # Check if they're less than 2 seconds apart, fall back to words per minute otherwise
                     if self.ctx_timestamps[closest_index][2] - seconds < 2:
-                        return " ".join([word for word, *_ in self.ctx_timestamps[:closest_index + 1]])
+                        return " ".join(
+                            [word for word, *_ in self.ctx_timestamps[: closest_index + 1]]
+                        )
             return self.get_message_cutoff_from_voice_speed(message, seconds, words_per_minute)
-
 
         return SynthesisResult(
             chunk_generator=chunk_generator(self.ctx),

--- a/vocode/streaming/synthesizer/cartesia_synthesizer.py
+++ b/vocode/streaming/synthesizer/cartesia_synthesizer.py
@@ -2,6 +2,7 @@ import asyncio
 import hashlib
 
 from loguru import logger
+from typing import List, Tuple
 
 from vocode import getenv
 from vocode.streaming.models.audio import AudioEncoding, SamplingRate
@@ -91,7 +92,7 @@ class CartesiaSynthesizer(BaseSynthesizer[CartesiaSynthesizerConfig]):
         self.ws = None
         self.ctx = None
         self.ctx_message = BaseMessage(text="")
-        self.ctx_timestamps = []
+        self.ctx_timestamps: List[Tuple[str, float, float]] = []
         self.no_more_inputs_task = None
         self.no_more_inputs_lock = asyncio.Lock()
 


### PR DESCRIPTION
## Overview
Discussed with [Ajay](https://github.com/ajar98) over Slack, recapping below.

There's a distinction between Cartesia's version of continuations and Vocode's general expectation for continuations. Vocode seems to expect an `N:N` ratio of senders to receivers, but our continuations is an `N:1` ratio of senders to receivers. Vocode's `get_message_up_to` also reflects this expected `N:N` approach.

The proposed solution to this is to start storing 2 new variables `self.ctx_message` and `self.ctx_timestamps`.  The Cartesia TTS now requests timestamps, and those timestamps are used to indicate what message we've gotten up to. In the event that the timestamps aren't available for some reason, or in the event that timestamps are delayed beyond a 2 second gap, we fall back to using an estimated wpm and the `self.ctx_message` to get a best approximation.

## Testing
I set up the `telephony_app` per the Vocode directions. I then adjusted the synthesizer and played around with it locally on my own Vocode deployment to check that it works as intended. 