### PR TITLE
Add language support to Cartesia synthesizer

### DIFF
--- a/vocode/streaming/models/synthesizer.py
+++ b/vocode/streaming/models/synthesizer.py
@@ -245,3 +245,4 @@ class CartesiaSynthesizerConfig(SynthesizerConfig, type=SynthesizerType.CARTESIA
     model_id: str = DEFAULT_CARTESIA_MODEL_ID
     voice_id: str = DEFAULT_CARTESIA_VOICE_ID
     experimental_voice_controls: Optional[CartesiaVoiceControls] = None
+    language: Optional[str] = None 

--- a/vocode/streaming/synthesizer/cartesia_synthesizer.py
+++ b/vocode/streaming/synthesizer/cartesia_synthesizer.py
@@ -152,6 +152,7 @@ class CartesiaSynthesizer(BaseSynthesizer[CartesiaSynthesizerConfig]):
                 continue_=not is_sole_text_chunk,
                 output_format=self.output_format,
                 add_timestamps=True,
+                language=self.synthesizer_config.language,
                 _experimental_voice_controls=self._experimental_voice_controls,
             )
             if not is_sole_text_chunk:


### PR DESCRIPTION
## Description
This PR addresses an error introduced by PR #700  which added timestamps to the Cartesia synthesizer. The previous change resulted in an error when generating audio due to a missing language specification. This PR adds proper language support to the Cartesia synthesizer, resolving the error and allowing users to specify the language for text-to-speech synthesis.

## Issue Fixed
Error message resolved: "Failed to generate audio: Error generating audio: error processing TTS request: Language must be specified for timestamps."

## Changes
- Added `language` attribute to `CartesiaSynthesizerConfig`
- Updated `CartesiaSynthesizer` to use the specified language
- Modified the `create_speech_uncached` method to include language in the Cartesia API call

## Testing
- Tested with French language setting :
```python
synthesizer=CartesiaSynthesizer(
            synthesizer_config=CartesiaSynthesizerConfig.from_output_device(
                output_device=output_device,
                model_id = "sonic-multilingual",
                voice_id = "65b25c5d-ff07-4687-a04c-da2f43ef6fa9",
                language="fr",
            )
        ),
```
- Verified that the Cartesia API correctly receives and processes the language parameter
