### PR TITLE
Support passing in custom connector for AsyncRequestor

### DIFF
--- a/vocode/streaming/utils/async_requester.py
+++ b/vocode/streaming/utils/async_requester.py
@@ -1,17 +1,22 @@
+from typing import Optional
+
 import aiohttp
 import httpx
+from aiohttp import BaseConnector
+from pydantic import BaseModel
 
 from vocode.streaming.utils.singleton import Singleton
 
 
 class AsyncRequestor(Singleton):
-    def __init__(self):
-        self.session = aiohttp.ClientSession()
+    def __init__(self, connector: Optional[BaseConnector] = None):
+        self.session = aiohttp.ClientSession(connector=connector)
         self.async_client = httpx.AsyncClient()
+        self.connector = connector
 
     def get_session(self):
         if self.session.closed:
-            self.session = aiohttp.ClientSession()
+            self.session = aiohttp.ClientSession(connector=self.connector)
         return self.session
 
     def get_client(self):


### PR DESCRIPTION
## Summary
In order to unlock more connections in the connection pool, we'll need to adjust the `limit` parameter of the connector used for the session: https://docs.aiohttp.org/en/stable/client_reference.html#connectors

This change supports the configuration but defaults to the previous behavior, which is to defer the connector creation to the session constructor.