### PR TITLE
Adds a log to see what caused an interrupt

### DIFF
--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -273,10 +273,9 @@ class StreamingConversation(AudioPipeline[OutputDeviceType]):
                 )
                 self.has_associated_unignored_utterance = not transcription.is_final
                 if self.conversation.current_transcription_is_interrupt:
-                    if self.conversation.transcript.get_last_user_message() is not None:
-                        logger.debug(
-                            f"Last user message when interrupted: {self.conversation.transcript.get_last_user_message()[1]}"
-                        )
+                    logger.debug(
+                        f"Interrupting transcription: {transcription.message}, confidence: {transcription.confidence}"
+                    )
                     logger.debug("sent interrupt")
                 logger.debug("Human started speaking")
                 self.conversation.is_human_still_there = True

--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -273,6 +273,10 @@ class StreamingConversation(AudioPipeline[OutputDeviceType]):
                 )
                 self.has_associated_unignored_utterance = not transcription.is_final
                 if self.conversation.current_transcription_is_interrupt:
+                    if self.conversation.transcript.get_last_user_message() is not None:
+                        logger.debug(
+                            f"Last user message when interrupted: {self.conversation.transcript.get_last_user_message()[1]}"
+                        )
                     logger.debug("sent interrupt")
                 logger.debug("Human started speaking")
                 self.conversation.is_human_still_there = True


### PR DESCRIPTION
## Summary
We were seeing a weird case of an interruption triggering when no utterance could be heard on the recording. Adding this log to understand what the program is processing for the interruption.