### PR TITLE
Don't close session on transfer call

### DIFF
--- a/vocode/streaming/action/transfer_call.py
+++ b/vocode/streaming/action/transfer_call.py
@@ -104,13 +104,14 @@ class TwilioTransferCall(
 
         payload = {"Twiml": twiml_data}
 
-        async with AsyncRequestor().get_session() as session:
-            async with session.post(url, data=payload, auth=twilio_client.auth) as response:
-                if response.status != 200:
-                    logger.error(f"Failed to transfer call: {response.status} {response.reason}")
-                    raise Exception("failed to update call")
-                else:
-                    return await response.json()
+        async with AsyncRequestor().get_session().post(
+            url, data=payload, auth=twilio_client.auth
+        ) as response:
+            if response.status != 200:
+                logger.error(f"Failed to transfer call: {response.status} {response.reason}")
+                raise Exception("failed to update call")
+            else:
+                return await response.json()
 
     async def run(
         self, action_input: ActionInput[TransferCallParameters]


### PR DESCRIPTION
## Summary
The `async with ... as session` will close the session at the end of the block. Because we use a singleton to handle sessions, this causes premature closing of the sessions for existing consumers. This change updates the `async with` to only close the response handler instead of the session so we can preserve the persistent session