### PR TITLE
remove deprecaited lc_kwargs in ChatGPTAgent and GroqAgent

### DIFF
--- a/vocode/streaming/agent/chat_gpt_agent.py
+++ b/vocode/streaming/agent/chat_gpt_agent.py
@@ -199,7 +199,7 @@ class ChatGPTAgent(RespondAgent[ChatGPTAgentConfigType]):
                         "Document: "
                         + doc[0].metadata["source"]
                         + f" (Confidence: {doc[1]})\n"
-                        + doc[0].lc_kwargs["page_content"].replace(r"\n", "\n")
+                        + doc[0].page_content.replace(r"\n", "\n")
                         for doc in docs_with_scores
                     ]
                 )

--- a/vocode/streaming/agent/groq_agent.py
+++ b/vocode/streaming/agent/groq_agent.py
@@ -145,7 +145,7 @@ class GroqAgent(RespondAgent[GroqAgentConfig]):
                         "Document: "
                         + doc[0].metadata["source"]
                         + f" (Confidence: {doc[1]})\n"
-                        + doc[0].lc_kwargs["page_content"].replace(r"\n", "\n")
+                        + doc[0].page_content.replace(r"\n", "\n")
                         for doc in docs_with_scores
                     ]
                 )


### PR DESCRIPTION
Remove the deprecated `lc_kwargs` parameter from `ChatGPTAgent` and `GroqAgent` when accessing page content from the Langchain `Document` retrieved from a vector db. The changes are necessary because the recommended Langchain version (0.2.3) no longer supports `lc_kwargs`. 
