### PR TITLE
dynamic provider selection for telephony services

### DIFF
--- a/tests/fakedata/conversation.py
+++ b/tests/fakedata/conversation.py
@@ -13,14 +13,14 @@ from vocode.streaming.output_device.abstract_output_device import AbstractOutput
 from vocode.streaming.output_device.audio_chunk import ChunkState
 from vocode.streaming.streaming_conversation import StreamingConversation
 from vocode.streaming.synthesizer.base_synthesizer import BaseSynthesizer
-from vocode.streaming.telephony.constants import DEFAULT_CHUNK_SIZE, DEFAULT_SAMPLING_RATE
+from vocode.streaming.telephony.constants import TWILIO_CHUNK_SIZE, TWILIO_SAMPLING_RATE
 from vocode.streaming.transcriber.base_transcriber import BaseTranscriber
 from vocode.streaming.transcriber.deepgram_transcriber import DeepgramEndpointingConfig
 from vocode.streaming.utils.events_manager import EventsManager
 
 DEFAULT_DEEPGRAM_TRANSCRIBER_CONFIG = DeepgramTranscriberConfig(
-    chunk_size=DEFAULT_CHUNK_SIZE,
-    sampling_rate=DEFAULT_SAMPLING_RATE,
+    chunk_size=TWILIO_CHUNK_SIZE,
+    sampling_rate=TWILIO_SAMPLING_RATE,
     audio_encoding=AudioEncoding.MULAW,
     endpointing_config=DeepgramEndpointingConfig(),
     model="2-phonecall",
@@ -29,7 +29,7 @@ DEFAULT_DEEPGRAM_TRANSCRIBER_CONFIG = DeepgramTranscriberConfig(
 
 DEFAULT_SYNTHESIZER_CONFIG = PlayHtSynthesizerConfig(
     voice_id="test_voice_id",
-    sampling_rate=DEFAULT_SAMPLING_RATE,
+    sampling_rate=TWILIO_SAMPLING_RATE,
     audio_encoding=AudioEncoding.MULAW,
 )
 
@@ -124,7 +124,7 @@ def create_fake_streaming_conversation(
     synthesizer = synthesizer or create_fake_synthesizer(mocker, DEFAULT_SYNTHESIZER_CONFIG)
     return StreamingConversation(
         output_device=DummyOutputDevice(
-            sampling_rate=DEFAULT_SAMPLING_RATE, audio_encoding=AudioEncoding.MULAW
+            sampling_rate=TWILIO_SAMPLING_RATE, audio_encoding=AudioEncoding.MULAW
         ),
         transcriber=transcriber,
         agent=agent,

--- a/vocode/streaming/models/synthesizer.py
+++ b/vocode/streaming/models/synthesizer.py
@@ -5,7 +5,12 @@ from pydantic.v1 import validator
 
 from vocode.streaming.models.client_backend import OutputAudioConfig
 from vocode.streaming.output_device.abstract_output_device import AbstractOutputDevice
-from vocode.streaming.telephony.constants import DEFAULT_AUDIO_ENCODING, DEFAULT_SAMPLING_RATE
+from vocode.streaming.telephony.constants import (
+    TWILIO_AUDIO_ENCODING,
+    TWILIO_SAMPLING_RATE,
+    VONAGE_AUDIO_ENCODING,
+    VONAGE_SAMPLING_RATE,
+)
 
 from .audio import AudioEncoding, SamplingRate
 from .model import BaseModel, TypedModel
@@ -54,11 +59,16 @@ class SynthesizerConfig(TypedModel, type=SynthesizerType.BASE.value):  # type: i
             **kwargs
         )
 
-    # TODO(EPD-186): switch to from_twilio_output_device and from_vonage_output_device
     @classmethod
-    def from_telephone_output_device(cls, **kwargs):
+    def from_twilio_output_device(cls, **kwargs):
         return cls(
-            sampling_rate=DEFAULT_SAMPLING_RATE, audio_encoding=DEFAULT_AUDIO_ENCODING, **kwargs
+            sampling_rate=TWILIO_SAMPLING_RATE, audio_encoding=TWILIO_AUDIO_ENCODING, **kwargs
+        )
+
+    @classmethod
+    def from_vonage_output_device(cls, **kwargs):
+        return cls(
+            sampling_rate=VONAGE_SAMPLING_RATE, audio_encoding=VONAGE_AUDIO_ENCODING, **kwargs
         )
 
     @classmethod

--- a/vocode/streaming/models/telephony.py
+++ b/vocode/streaming/models/telephony.py
@@ -10,9 +10,9 @@ from vocode.streaming.models.transcriber import (
     TranscriberConfig,
 )
 from vocode.streaming.telephony.constants import (
-    DEFAULT_AUDIO_ENCODING,
-    DEFAULT_CHUNK_SIZE,
-    DEFAULT_SAMPLING_RATE,
+    TWILIO_AUDIO_ENCODING,
+    TWILIO_CHUNK_SIZE,
+    TWILIO_SAMPLING_RATE,
     VONAGE_AUDIO_ENCODING,
     VONAGE_CHUNK_SIZE,
     VONAGE_SAMPLING_RATE,
@@ -121,9 +121,9 @@ class TwilioCallConfig(BaseCallConfig, type=CallConfigType.TWILIO.value):  # typ
     @staticmethod
     def default_transcriber_config():
         return DeepgramTranscriberConfig(
-            sampling_rate=DEFAULT_SAMPLING_RATE,
-            audio_encoding=DEFAULT_AUDIO_ENCODING,
-            chunk_size=DEFAULT_CHUNK_SIZE,
+            sampling_rate=TWILIO_SAMPLING_RATE,
+            audio_encoding=TWILIO_AUDIO_ENCODING,
+            chunk_size=TWILIO_CHUNK_SIZE,
             model="phonecall",
             tier="nova",
             endpointing_config=PunctuationEndpointingConfig(),
@@ -132,8 +132,8 @@ class TwilioCallConfig(BaseCallConfig, type=CallConfigType.TWILIO.value):  # typ
     @staticmethod
     def default_synthesizer_config():
         return AzureSynthesizerConfig(
-            sampling_rate=DEFAULT_SAMPLING_RATE,
-            audio_encoding=DEFAULT_AUDIO_ENCODING,
+            sampling_rate=TWILIO_SAMPLING_RATE,
+            audio_encoding=TWILIO_AUDIO_ENCODING,
         )
 
 

--- a/vocode/streaming/models/transcriber.py
+++ b/vocode/streaming/models/transcriber.py
@@ -8,9 +8,12 @@ from vocode.streaming.input_device.base_input_device import BaseInputDevice
 from vocode.streaming.models.client_backend import InputAudioConfig
 from vocode.streaming.models.model import BaseModel
 from vocode.streaming.telephony.constants import (
-    DEFAULT_AUDIO_ENCODING,
-    DEFAULT_CHUNK_SIZE,
-    DEFAULT_SAMPLING_RATE,
+    TWILIO_AUDIO_ENCODING,
+    TWILIO_CHUNK_SIZE,
+    TWILIO_SAMPLING_RATE,
+    VONAGE_AUDIO_ENCODING,
+    VONAGE_CHUNK_SIZE,
+    VONAGE_SAMPLING_RATE,
 )
 
 from .audio import AudioEncoding
@@ -81,17 +84,30 @@ class TranscriberConfig(TypedModel, type=TranscriberType.BASE.value):  # type: i
             **kwargs,
         )
 
-    # TODO(EPD-186): switch to from_twilio_input_device and from_vonage_input_device
     @classmethod
-    def from_telephone_input_device(
+    def from_twilio_input_device(
         cls,
         endpointing_config: Optional[EndpointingConfig] = None,
         **kwargs,
     ):
         return cls(
-            sampling_rate=DEFAULT_SAMPLING_RATE,
-            audio_encoding=DEFAULT_AUDIO_ENCODING,
-            chunk_size=DEFAULT_CHUNK_SIZE,
+            sampling_rate=TWILIO_SAMPLING_RATE,
+            audio_encoding=TWILIO_AUDIO_ENCODING,
+            chunk_size=TWILIO_CHUNK_SIZE,
+            endpointing_config=endpointing_config,
+            **kwargs,
+        )
+
+    @classmethod
+    def from_vonage_input_device(
+        cls,
+        endpointing_config: Optional[EndpointingConfig] = None,
+        **kwargs,
+    ):
+        return cls(
+            sampling_rate=VONAGE_SAMPLING_RATE,
+            audio_encoding=VONAGE_AUDIO_ENCODING,
+            chunk_size=VONAGE_CHUNK_SIZE,
             endpointing_config=endpointing_config,
             **kwargs,
         )

--- a/vocode/streaming/output_device/twilio_output_device.py
+++ b/vocode/streaming/output_device/twilio_output_device.py
@@ -13,7 +13,7 @@ from pydantic import BaseModel
 
 from vocode.streaming.output_device.abstract_output_device import AbstractOutputDevice
 from vocode.streaming.output_device.audio_chunk import AudioChunk, ChunkState
-from vocode.streaming.telephony.constants import DEFAULT_AUDIO_ENCODING, DEFAULT_SAMPLING_RATE
+from vocode.streaming.telephony.constants import TWILIO_AUDIO_ENCODING, TWILIO_SAMPLING_RATE
 from vocode.streaming.utils.create_task import asyncio_create_task
 from vocode.streaming.utils.dtmf_utils import DTMFToneGenerator, KeypadEntry
 from vocode.streaming.utils.worker import InterruptibleEvent
@@ -28,7 +28,7 @@ MarkMessage = Union[ChunkFinishedMarkMessage]  # space for more mark messages
 
 class TwilioOutputDevice(AbstractOutputDevice):
     def __init__(self, ws: Optional[WebSocket] = None, stream_sid: Optional[str] = None):
-        super().__init__(sampling_rate=DEFAULT_SAMPLING_RATE, audio_encoding=DEFAULT_AUDIO_ENCODING)
+        super().__init__(sampling_rate=TWILIO_SAMPLING_RATE, audio_encoding=TWILIO_AUDIO_ENCODING)
         self.ws = ws
         self.stream_sid = stream_sid
         self.active = True

--- a/vocode/streaming/telephony/constants.py
+++ b/vocode/streaming/telephony/constants.py
@@ -1,9 +1,8 @@
 from vocode.streaming.models.audio import AudioEncoding, SamplingRate
 
-# TODO(EPD-186): namespace as Twilio
-DEFAULT_SAMPLING_RATE: int = SamplingRate.RATE_8000.value
-DEFAULT_AUDIO_ENCODING = AudioEncoding.MULAW
-DEFAULT_CHUNK_SIZE = 20 * 160
+TWILIO_SAMPLING_RATE: int = SamplingRate.RATE_8000.value
+TWILIO_AUDIO_ENCODING = AudioEncoding.MULAW
+TWILIO_CHUNK_SIZE = 20 * 160
 MULAW_SILENCE_BYTE = b"\xff"
 
 VONAGE_SAMPLING_RATE: int = SamplingRate.RATE_16000.value


### PR DESCRIPTION
Related to issue #501 

Updated telephony output and input device methods to allow for dynamic provider changes.

What was done:
- Updated the namespaces of constants in `constants.py`.
- Modified `from_telephone_output_device` and `from_telephone_input_device` methods in `synthesizer.py` and `transcriber.py` respectively to support both Twilio and Vonage.